### PR TITLE
Codebase security audit

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,82 @@
+# Security Audit Notes (Application Layer)
+
+Date: 2026-02-21  
+Scope: NoScope application behavior and runtime safety controls (not generated MVP app security posture)
+
+## Executive Summary
+
+This audit focused on end-user security risks in NoScope itself, with extra emphasis on accidental secret leakage.  
+Several high-risk leak paths were identified and fixed:
+
+1. Tool telemetry logged sensitive arguments/results directly to `events.jsonl`
+2. Shell subprocesses inherited sensitive environment variables (including API keys)
+3. Path boundary checks used unsafe prefix matching, allowing workspace-escape edge cases
+4. Event log file permissions were not hardened (potential overexposure on permissive umask)
+5. Redaction coverage was narrow and missed common credential/header/private-key patterns
+
+## Findings and Fixes
+
+### 1) Sensitive tool telemetry persisted unredacted
+
+- **Affected file(s):** `noscope/tools/dispatcher.py`
+- **Risk:** Tool call args/results (including file content and command output) were logged raw.  
+  This could persist secrets in `.noscope/runs/.../events.jsonl`.
+- **Fix implemented:**
+  - Added recursive redaction for nested tool payloads before logging
+  - Added payload trimming for bulky/sensitive fields (`content`, `stdout`, `stderr`)
+  - Added string truncation guard for large values
+
+### 2) Event log accepted and stored raw secret-looking values
+
+- **Affected file(s):** `noscope/logging/events.py`
+- **Risk:** Non-tool events could still persist token-like data in summaries/data/results.
+- **Fix implemented:**
+  - Added automatic redaction on all event payload strings
+  - Added owner-only file permissions (`0600`) for `events.jsonl` (best effort)
+
+### 3) Shell and launched app inherited full host environment
+
+- **Affected file(s):** `noscope/tools/shell.py`, `noscope/orchestrator.py`
+- **Risk:** LLM-directed shell commands (and launched demos) could access provider keys or other tokens from environment.
+- **Fix implemented:**
+  - Introduced `build_execution_env()` to strip sensitive env vars and clean `.venv` path entries
+  - Reused hardened env construction for both shell tool execution and app launch
+  - Added runtime secret map into `ToolContext` so known provider keys are explicitly redacted in outputs
+
+### 4) Workspace path checks were bypassable via prefix collision
+
+- **Affected file(s):** `noscope/tools/safety.py`, `noscope/tools/shell.py`
+- **Risk:** Prefix-based `startswith` checks could treat sibling paths like `/tmp/ws-evil` as if inside `/tmp/ws`.
+- **Fix implemented:**
+  - Replaced prefix matching with robust `Path.relative_to(...)` containment checks
+  - Applied this containment enforcement to shell `cwd` resolution
+
+### 5) Redaction coverage insufficient for modern secret formats
+
+- **Affected file(s):** `noscope/tools/redaction.py`, `noscope/tools/docker.py`
+- **Risk:** Existing redaction missed common auth headers, multiple token formats, and private key blocks.
+- **Fix implemented:**
+  - Expanded redaction patterns for:
+    - assignment-style secret values (quoted/unquoted)
+    - auth headers (`Authorization`, `x-api-key`)
+    - common provider token formats
+    - PEM private key blocks
+  - Added `redact_text()` and `redact_structured()` helpers
+  - Updated Docker shell output redaction to use expanded redaction pipeline
+
+## Validation
+
+- Lint: `python3 -m ruff check noscope tests` ✅
+- Tests: `python3 -m pytest -q` ✅ (102 passed)
+- Added regression tests covering:
+  - path prefix collision bypass prevention
+  - env stripping for subprocess execution
+  - nested payload redaction and log field omission
+  - event log redaction and file permission hardening
+
+## Residual Risk / Future Hardening
+
+- A warning in shell-tool tests indicates asyncio subprocess transport cleanup behavior under test shutdown; not a functional failure but worth future cleanup.
+- Optional future work:
+  - introduce explicit redaction/deny controls for reading highly sensitive file classes (`.env`, private keys) in `read_file`
+  - add structured security mode toggles for stricter enterprise defaults

--- a/noscope/tools/docker.py
+++ b/noscope/tools/docker.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from noscope.capabilities import Capability
 from noscope.tools.base import Tool, ToolContext, ToolResult
-from noscope.tools.redaction import redact
+from noscope.tools.redaction import redact_text
 from noscope.tools.safety import check_command_safety
 
 DOCKER_IMAGE = "python:3.12-slim"
@@ -138,8 +138,8 @@ class DockerShellTool(Tool):
         except RuntimeError as e:
             return ToolResult.error(str(e))
 
-        stdout = redact(stdout, context.secrets)
-        stderr = redact(stderr, context.secrets)
+        stdout = redact_text(stdout, context.secrets)
+        stderr = redact_text(stderr, context.secrets)
 
         display = stdout
         if stderr:

--- a/noscope/tools/redaction.py
+++ b/noscope/tools/redaction.py
@@ -3,28 +3,78 @@
 from __future__ import annotations
 
 import re
+from typing import Any
+
+# Keep assignment key names while redacting the value.
+_SENSITIVE_ASSIGNMENT = re.compile(
+    r"""(?ix)
+    (\b(?:api[_-]?key|secret|token|password|credential(?:s)?)\b\s*[:=]\s*)
+    (?:"[^"\n]*"|'[^'\n]*'|[^\s,;]+)
+    """
+)
+
+_AUTH_HEADER_ASSIGNMENT = re.compile(
+    r"""(?ix)
+    (\b(?:authorization|x-api-key)\b\s*[:=]\s*)
+    (?:bearer\s+)?[^\s,;]+
+    """
+)
+
+_TOKEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bsk-ant-[A-Za-z0-9\-]{20,}\b"),
+    re.compile(r"\bghp_[A-Za-z0-9]{36}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{40,}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z\-_]{35}\b"),
+)
+
+_PRIVATE_KEY_BLOCK = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----"
+)
 
 
 def redact(text: str, secrets: dict[str, str]) -> str:
-    """Replace secret values in text with [REDACTED:<name>]."""
+    """Replace explicit secret values in text with [REDACTED:<name>]."""
     if not secrets:
         return text
 
+    # Replace longer values first to avoid partial replacements.
+    ordered = sorted(
+        ((name, value) for name, value in secrets.items() if value),
+        key=lambda item: len(item[1]),
+        reverse=True,
+    )
+
     result = text
-    for name, value in secrets.items():
-        if value:
-            result = result.replace(value, f"[REDACTED:{name}]")
+    for name, value in ordered:
+        result = result.replace(value, f"[REDACTED:{name}]")
     return result
 
 
 def redact_env_vars(text: str) -> str:
-    """Redact common environment variable patterns that look like secrets."""
-    patterns = [
-        r'(?:API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)=[^\s"\']+',
-        r'sk-[a-zA-Z0-9]{20,}',
-        r'sk-ant-[a-zA-Z0-9\-]{20,}',
-    ]
-    result = text
-    for pattern in patterns:
-        result = re.sub(pattern, "[REDACTED:auto]", result)
-    return result
+    """Redact common token, env-var, and private-key patterns."""
+    result = _SENSITIVE_ASSIGNMENT.sub(r"\1[REDACTED:auto]", text)
+    result = _AUTH_HEADER_ASSIGNMENT.sub(r"\1[REDACTED:auto]", result)
+
+    for pattern in _TOKEN_PATTERNS:
+        result = pattern.sub("[REDACTED:auto]", result)
+
+    return _PRIVATE_KEY_BLOCK.sub("[REDACTED:auto]", result)
+
+
+def redact_text(text: str, secrets: dict[str, str]) -> str:
+    """Apply explicit and automatic redaction to text."""
+    return redact_env_vars(redact(text, secrets))
+
+
+def redact_structured(data: Any, secrets: dict[str, str]) -> Any:
+    """Recursively redact secrets from nested structures."""
+    if isinstance(data, str):
+        return redact_text(data, secrets)
+    if isinstance(data, dict):
+        return {k: redact_structured(v, secrets) for k, v in data.items()}
+    if isinstance(data, list):
+        return [redact_structured(item, secrets) for item in data]
+    if isinstance(data, tuple):
+        return tuple(redact_structured(item, secrets) for item in data)
+    return data

--- a/tests/test_tools/test_dispatcher.py
+++ b/tests/test_tools/test_dispatcher.py
@@ -1,0 +1,55 @@
+"""Tests for tool dispatcher logging hygiene."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from noscope.capabilities import Capability
+from noscope.tools.base import Tool, ToolContext, ToolResult
+from noscope.tools.dispatcher import ToolDispatcher
+
+
+class _DummyTool(Tool):
+    name = "dummy_tool"
+    description = "Dummy tool for dispatcher tests"
+    required_capability = Capability.WORKSPACE_RW
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {"content": {"type": "string"}}}
+
+    async def execute(self, args: dict[str, Any], context: ToolContext) -> ToolResult:
+        return ToolResult.ok(
+            display="done",
+            content=args.get("content", ""),
+            stdout="Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz123456",
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_redacts_and_omits_bulky_fields(tool_context: ToolContext) -> None:
+    tool_context.secrets = {"OPENAI_API_KEY": "supersecret123"}
+    dispatcher = ToolDispatcher()
+    dispatcher.register(_DummyTool())
+
+    payload = {"content": "A" * 5000, "token": "supersecret123"}
+    result = await dispatcher.dispatch("dummy_tool", payload, tool_context)
+    assert result.status == "ok"
+
+    events_path = tool_context.event_log.run_dir.events_path
+    lines = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+    assert len(lines) == 2
+
+    call_event = lines[0]
+    result_event = lines[1]
+
+    assert call_event["data"]["args"]["content"].startswith("[omitted ")
+    assert call_event["data"]["args"]["token"] == "[REDACTED:OPENAI_API_KEY]"
+    assert result_event["result"]["data"]["content"].startswith("[omitted ")
+    assert result_event["result"]["data"]["stdout"].startswith("[omitted ")
+
+    raw = events_path.read_text(encoding="utf-8")
+    assert "supersecret123" not in raw
+    assert "sk-abcdefghijklmnopqrstuvwxyz123456" not in raw

--- a/tests/test_tools/test_shell.py
+++ b/tests/test_tools/test_shell.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from noscope.tools.base import ToolContext
-from noscope.tools.shell import ShellTool
+from noscope.tools.shell import ShellTool, build_execution_env
 
 
 @pytest.mark.asyncio
@@ -46,6 +46,15 @@ class TestShellTool:
         assert result.status == "ok"
         assert "subdir" in result.display
 
+    async def test_cwd_outside_workspace_denied(self, tool_context: ToolContext) -> None:
+        tool = ShellTool()
+        result = await tool.execute(
+            {"command": "pwd", "cwd": "/"},
+            tool_context,
+        )
+        assert result.status == "error"
+        assert "outside workspace" in result.display.lower()
+
     async def test_secret_redaction(self, tool_context: ToolContext) -> None:
         tool_context.secrets = {"MY_SECRET": "supersecret123"}
         tool = ShellTool()
@@ -54,3 +63,17 @@ class TestShellTool:
         )
         assert "supersecret123" not in result.display
         assert "[REDACTED:MY_SECRET]" in result.display
+
+
+def test_build_execution_env_strips_sensitive_values() -> None:
+    env = {
+        "PATH": "/usr/bin:/tmp/project/.venv/bin:/bin",
+        "OPENAI_API_KEY": "sk-test-secret",
+        "GITHUB_TOKEN": "ghp_verysecret",
+        "HOME": "/home/test",
+    }
+    cleaned = build_execution_env(env)
+    assert "OPENAI_API_KEY" not in cleaned
+    assert "GITHUB_TOKEN" not in cleaned
+    assert "/tmp/project/.venv/bin" not in cleaned["PATH"]
+    assert cleaned["HOME"] == "/home/test"


### PR DESCRIPTION
## What

This PR implements a comprehensive security hardening pass for the NoScope application, focusing on preventing secret leakage and improving isolation.

## Why

An aggressive security audit identified several high-risk vulnerabilities related to sensitive data exposure. These include:
*   Unsafe logging of tool arguments and results (e.g., file contents, command output, API keys) to `events.jsonl`.
*   Subprocesses (shell commands, launched app servers) inheriting sensitive environment variables from the host.
*   Insecure workspace path validation allowing potential path traversal.
*   Insufficient redaction patterns for various secret formats.
*   Lax permissions for the `events.jsonl` log file.

The goal is to protect end-user secrets and prevent accidental exposure within the application's operational context.

## How

The following measures were implemented:
*   **Secret Redaction:** Introduced recursive, pattern-based redaction for all structured event payloads and tool arguments/results before logging to `events.jsonl`. Expanded redaction patterns to cover a wider range of secret formats (API keys, tokens, PEM blocks, etc.).
*   **Environment Hardening:** Implemented a mechanism to strip sensitive environment variables (e.g., API keys, tokens, passwords) from subprocesses executed by the agent and when launching generated app servers.
*   **Workspace Containment:** Replaced prefix-based path checks with robust `Path.relative_to(...)` validation and enforced workspace-safe resolution for shell `cwd`.
*   **Log File Permissions:** Set `events.jsonl` permissions to owner-only (`0600`) where supported.
*   **Documentation:** Added a `SECURITY_AUDIT.md` file detailing findings, fixes, and validation.

## Testing

- [x] `make test` passes (verified `python3 -m pytest -q`)
- [x] `make lint` passes (verified `python3 -m ruff check`)
- [ ] `make typecheck` passes
- [x] New tests added for new functionality (e.g., `test_redaction.py`, `test_dispatcher.py`, updated `test_safety.py`, `test_shell.py`, `test_event_logging.py`)

## Related Issues

Closes #

---
<p><a href="https://cursor.com/agents?id=bc-802f1a2a-296c-4b5a-ad68-43484f9467dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-802f1a2a-296c-4b5a-ad68-43484f9467dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

