### PR TITLE
Feed audit findings back to workers, group transitive dep chains

### DIFF
--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -21,6 +21,43 @@ MAX_AGENT_ITERATIONS = 200
 TIME_STATUS_INTERVAL = 3  # Inject time status every N tool calls
 
 
+class AuditFeed:
+    """Shared channel between the audit agent and build agents.
+
+    The audit agent publishes findings; each worker polls for findings it
+    hasn't seen yet and injects them into its own conversation. Findings are
+    deduplicated by (type, message) so workers aren't re-alerted every audit
+    cycle for the same unresolved issue.
+    """
+
+    def __init__(self) -> None:
+        self._findings: list[dict[str, Any]] = []
+        self._seen_keys: set[tuple[str, str]] = set()
+        self._cursors: dict[str, int] = {}
+
+    def publish(self, findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Add findings to the feed. Returns only the findings that are new."""
+        new: list[dict[str, Any]] = []
+        for finding in findings:
+            key = (str(finding.get("type", "")), str(finding.get("message", "")))
+            if key in self._seen_keys:
+                continue
+            self._seen_keys.add(key)
+            self._findings.append(finding)
+            new.append(finding)
+        return new
+
+    def poll(self, consumer_id: str) -> list[dict[str, Any]]:
+        """Return findings published since this consumer's last poll."""
+        cursor = self._cursors.get(consumer_id, 0)
+        self._cursors[consumer_id] = len(self._findings)
+        return self._findings[cursor:]
+
+    @property
+    def all_findings(self) -> list[dict[str, Any]]:
+        return list(self._findings)
+
+
 class BuildAgent:
     """An autonomous agent that works on assigned tasks.
 
@@ -39,6 +76,7 @@ class BuildAgent:
         deadline: Deadline,
         ui: ConsoleUI | None = None,
         tokens: TokenTracker | None = None,
+        feed: AuditFeed | None = None,
     ) -> None:
         self.agent_id = agent_id
         self.provider = provider
@@ -48,6 +86,7 @@ class BuildAgent:
         self.deadline = deadline
         self.ui = ui
         self.tokens = tokens
+        self.feed = feed
         self._tool_call_count = 0
 
     async def run(
@@ -108,6 +147,12 @@ class BuildAgent:
                 )
                 break
 
+            # Surface new audit findings before the next LLM turn so the
+            # worker can course-correct instead of building on broken files
+            audit_message = self._poll_audit_feed()
+            if audit_message:
+                messages.append(Message(role="user", content=audit_message))
+
             response = await self.provider.complete(messages, tools=tool_schemas)
             if self.tokens:
                 self.tokens.add(response.usage)
@@ -152,6 +197,28 @@ class BuildAgent:
                 )
 
         return tasks
+
+    def _poll_audit_feed(self) -> str | None:
+        """Check the audit feed for new findings and format them as a correction prompt."""
+        if self.feed is None:
+            return None
+        findings = self.feed.poll(self.agent_id)
+        if not findings:
+            return None
+
+        self.event_log.emit(
+            phase=Phase.BUILD.value,
+            event_type="audit.feedback",
+            summary=f"[{self.agent_id}] Received {len(findings)} audit finding(s)",
+            data={"agent_id": self.agent_id, "findings": findings},
+        )
+
+        lines = "\n".join(f"- [{f.get('type', 'issue')}] {f.get('message', '')}" for f in findings)
+        return (
+            f"⚠ AUDIT ALERT — the audit agent found issue(s) in the workspace:\n{lines}\n"
+            "If any of these relate to files you wrote or your assigned tasks, "
+            "fix them now before continuing. Otherwise, continue your tasks."
+        )
 
     async def _execute_tool_calls(
         self,
@@ -245,33 +312,40 @@ class AuditAgent:
         event_log: EventLog,
         deadline: Deadline,
         ui: ConsoleUI | None = None,
+        feed: AuditFeed | None = None,
     ) -> None:
         self.dispatcher = dispatcher
         self.context = context
         self.event_log = event_log
         self.deadline = deadline
         self.ui = ui
+        self.feed = feed if feed is not None else AuditFeed()
 
     async def run_continuous(self, check_interval: float = 20.0) -> list[dict[str, Any]]:
-        """Run periodic validation checks. Returns list of findings."""
-        findings: list[dict[str, Any]] = []
+        """Run periodic validation checks. Returns list of findings.
 
+        New findings are published to the audit feed so worker agents can
+        pick them up and fix issues mid-build.
+        """
         # Wait for workers to write some files first
         await asyncio.sleep(min(check_interval, self.deadline.phase_remaining(Phase.BUILD) / 3))
 
         while not self.deadline.is_expired() and self.deadline.phase_remaining(Phase.BUILD) > 30:
             check_result = await self._run_checks()
             if check_result:
-                findings.extend(check_result)
-                self.event_log.emit(
-                    phase=Phase.BUILD.value,
-                    event_type="audit.finding",
-                    summary=f"Audit found {len(check_result)} issue(s)",
-                    data={"findings": check_result},
-                )
+                # Publish to the shared feed; only genuinely new findings
+                # (deduplicated by type + message) get logged and surfaced
+                new_findings = self.feed.publish(check_result)
+                if new_findings:
+                    self.event_log.emit(
+                        phase=Phase.BUILD.value,
+                        event_type="audit.finding",
+                        summary=f"Audit found {len(new_findings)} new issue(s)",
+                        data={"findings": new_findings},
+                    )
             await asyncio.sleep(check_interval)
 
-        return findings
+        return self.feed.all_findings
 
     async def _run_checks(self) -> list[dict[str, Any]]:
         """Run quick validation checks on the workspace."""

--- a/noscope/supervisor.py
+++ b/noscope/supervisor.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from noscope.agents import AuditAgent, BuildAgent
+from noscope.agents import AuditAgent, AuditFeed, BuildAgent
 from noscope.deadline import Deadline, Phase
 from noscope.llm.base import LLMProvider
 from noscope.logging.events import EventLog
@@ -131,6 +131,7 @@ class Supervisor:
             )
 
         # Phase 2: Parallel workers on remaining tasks
+        audit_findings: list[object] = []
         if remaining_tasks and not self.deadline.is_expired():
             streams = self._partition_tasks(remaining_tasks)
             num_workers = len(streams)
@@ -152,6 +153,9 @@ class Supervisor:
                 },
             )
 
+            # Shared feed: audit publishes findings, workers poll and fix
+            feed = AuditFeed()
+
             worker_coros = []
             for i, stream in enumerate(streams):
                 agent = BuildAgent(
@@ -163,6 +167,7 @@ class Supervisor:
                     deadline=self.deadline,
                     ui=self.ui,
                     tokens=self.tokens,
+                    feed=feed,
                 )
                 prompt = self._worker_prompt(plan, workspace, stream, i)
                 worker_coros.append(agent.run(stream, prompt))
@@ -174,6 +179,7 @@ class Supervisor:
                 event_log=self.event_log,
                 deadline=self.deadline,
                 ui=self.ui,
+                feed=feed,
             )
             audit_coro = audit.run_continuous()
 
@@ -193,13 +199,23 @@ class Supervisor:
                         data={"agent": label, "error": str(result), "type": type(result).__name__},
                     )
 
+            # The final gather slot is the audit agent's findings
+            last_result = gather_results[-1] if gather_results else None
+            if isinstance(last_result, list):
+                audit_findings = last_result
+
         # Summary
         completed = sum(1 for t in all_tasks if t.completed)
         self.event_log.emit(
             phase=Phase.BUILD.value,
             event_type="supervisor.done",
-            summary=f"Build complete: {completed}/{len(all_tasks)} tasks done",
-            data={"completed": completed, "total": len(all_tasks)},
+            summary=f"Build complete: {completed}/{len(all_tasks)} tasks done"
+            + (f", {len(audit_findings)} audit finding(s)" if audit_findings else ""),
+            data={
+                "completed": completed,
+                "total": len(all_tasks),
+                "audit_findings": audit_findings,
+            },
         )
 
         return all_tasks
@@ -228,48 +244,78 @@ class Supervisor:
     def _partition_tasks(self, tasks: list[PlanTask]) -> list[list[PlanTask]]:
         """Partition tasks into parallel work streams.
 
-        Uses task dependencies if available, otherwise round-robin assignment.
-        Limits to MAX_WORKERS streams.
+        Builds the full dependency graph and groups each transitively-connected
+        component into a single stream, so a worker never waits on files owned
+        by another worker. Streams are ordered topologically (plan order as
+        tiebreak) and merged down to at most MAX_WORKERS.
         """
         if not tasks:
             return []
 
-        # Group by dependency chains
-        streams: list[list[PlanTask]] = []
-        assigned: set[str] = set()
+        task_ids = {t.id for t in tasks}
+        order = {t.id: i for i, t in enumerate(tasks)}
 
-        # First pass: group tasks that depend on each other
+        # Union-find over dependency edges (ignoring deps outside this task
+        # set, e.g. the already-completed setup task)
+        parent = {t.id: t.id for t in tasks}
+
+        def find(x: str) -> str:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        def union(a: str, b: str) -> None:
+            ra, rb = find(a), find(b)
+            if ra != rb:
+                parent[rb] = ra
+
         for task in tasks:
-            if task.id in assigned:
-                continue
+            for dep in task.depends_on:
+                if dep in task_ids:
+                    union(dep, task.id)
 
-            chain = [task]
-            assigned.add(task.id)
+        # Collect components, preserving plan order within and across them
+        components: dict[str, list[PlanTask]] = {}
+        for task in tasks:
+            components.setdefault(find(task.id), []).append(task)
+        streams = [self._topo_sort(chain) for chain in components.values()]
 
-            # Find tasks that depend on this one
-            for other in tasks:
-                if other.id not in assigned and task.id in other.depends_on:
-                    chain.append(other)
-                    assigned.add(other.id)
-
-            streams.append(chain)
-
-        # If we have more streams than workers, merge small ones
+        # Merge the smallest streams until we're within the worker limit
         while len(streams) > MAX_WORKERS:
-            # Merge the two shortest streams
             streams.sort(key=len)
             smallest = streams.pop(0)
-            streams[0] = smallest + streams[0]
-
-        # If we have unassigned tasks, distribute round-robin
-        unassigned = [t for t in tasks if t.id not in assigned]
-        for i, task in enumerate(unassigned):
-            idx = i % len(streams) if streams else 0
-            if not streams:
-                streams.append([])
-            streams[idx].append(task)
+            merged = sorted(smallest + streams[0], key=lambda t: order[t.id])
+            streams[0] = merged
 
         return streams
+
+    @staticmethod
+    def _topo_sort(tasks: list[PlanTask]) -> list[PlanTask]:
+        """Order tasks so dependencies come before dependents (plan order as tiebreak).
+
+        Tasks in a dependency cycle fall back to plan order at the end.
+        """
+        task_ids = {t.id for t in tasks}
+        emitted: set[str] = set()
+        result: list[PlanTask] = []
+        pending = list(tasks)
+
+        while pending:
+            ready = [
+                t
+                for t in pending
+                if all(dep in emitted or dep not in task_ids for dep in t.depends_on)
+            ]
+            if not ready:  # dependency cycle — emit remaining in plan order
+                result.extend(pending)
+                break
+            for t in ready:
+                emitted.add(t.id)
+                result.append(t)
+            pending = [t for t in pending if t.id not in emitted]
+
+        return result
 
     def _setup_structure_prompt(self, plan: PlanOutput, workspace: Path) -> str:
         return f"""\

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from noscope.agents import AuditAgent, BuildAgent
+from noscope.agents import AuditAgent, AuditFeed, BuildAgent
 from noscope.deadline import Deadline
 from noscope.llm.base import LLMResponse, Message, StreamChunk, ToolCall, ToolSchema, Usage
 from noscope.planning.models import PlanTask
@@ -149,6 +149,45 @@ class TestSupervisor:
         supervisor = Supervisor.__new__(Supervisor)
         assert supervisor._partition_tasks([]) == []
 
+    def test_partition_groups_transitive_chains(self) -> None:
+        # t4 -> t3 -> t2 is a transitive chain: all three must share a stream
+        # even though t4 never directly names t2 (issue #3)
+        supervisor = Supervisor.__new__(Supervisor)
+        tasks = [
+            PlanTask(id="t2", title="Models", kind="edit", depends_on=["t1"]),
+            PlanTask(id="t3", title="API", kind="edit", depends_on=["t2"]),
+            PlanTask(id="t5", title="Docs", kind="edit", depends_on=["t1"]),
+            PlanTask(id="t4", title="Frontend", kind="edit", depends_on=["t3"]),
+        ]
+        streams = supervisor._partition_tasks(tasks)
+        chain_stream = next(s for s in streams if any(t.id == "t2" for t in s))
+        chain_ids = [t.id for t in chain_stream]
+        assert "t3" in chain_ids
+        assert "t4" in chain_ids
+        # Dependencies come before dependents within the stream
+        assert chain_ids.index("t2") < chain_ids.index("t3") < chain_ids.index("t4")
+        # Independent task lands in its own stream
+        assert any(t.id == "t5" for s in streams for t in s if s is not chain_stream)
+
+    def test_partition_respects_max_workers(self) -> None:
+        from noscope.supervisor import MAX_WORKERS
+
+        supervisor = Supervisor.__new__(Supervisor)
+        tasks = [PlanTask(id=f"t{i}", title=f"Task {i}", kind="edit") for i in range(2, 10)]
+        streams = supervisor._partition_tasks(tasks)
+        assert len(streams) <= MAX_WORKERS
+        all_ids = {t.id for s in streams for t in s}
+        assert all_ids == {t.id for t in tasks}
+
+    def test_topo_sort_handles_cycles(self) -> None:
+        tasks = [
+            PlanTask(id="t2", title="A", kind="edit", depends_on=["t3"]),
+            PlanTask(id="t3", title="B", kind="edit", depends_on=["t2"]),
+        ]
+        # Cycle must not hang; falls back to plan order
+        result = Supervisor._topo_sort(tasks)
+        assert [t.id for t in result] == ["t2", "t3"]
+
     def test_split_setup_with_no_setup_keyword(self) -> None:
         supervisor = Supervisor.__new__(Supervisor)
         tasks = [
@@ -159,6 +198,72 @@ class TestSupervisor:
         # First task should always be setup
         assert len(setup) == 1
         assert setup[0].id == "t1"
+
+
+class TestAuditFeed:
+    def test_publish_dedupes_by_type_and_message(self) -> None:
+        feed = AuditFeed()
+        finding = {"type": "invalid_json", "message": "package.json is invalid"}
+        assert feed.publish([finding]) == [finding]
+        # Same finding republished (audit re-detects each cycle) is dropped
+        assert feed.publish([dict(finding)]) == []
+        other = {"type": "invalid_json", "message": "tsconfig.json is invalid"}
+        assert feed.publish([other]) == [other]
+        assert feed.all_findings == [finding, other]
+
+    def test_poll_tracks_per_consumer_cursors(self) -> None:
+        feed = AuditFeed()
+        f1 = {"type": "missing_files", "message": "no entry point"}
+        f2 = {"type": "invalid_json", "message": "bad package.json"}
+        feed.publish([f1])
+        assert feed.poll("worker-0") == [f1]
+        assert feed.poll("worker-0") == []  # already seen
+        feed.publish([f2])
+        assert feed.poll("worker-0") == [f2]
+        # A different consumer sees everything from the start
+        assert feed.poll("worker-1") == [f1, f2]
+
+    @pytest.mark.asyncio
+    async def test_build_agent_injects_audit_findings(self, tool_context: ToolContext) -> None:
+        from noscope.logging.events import EventLog, RunDir
+        from noscope.tools.dispatcher import ToolDispatcher
+
+        seen_messages: list[list[Message]] = []
+
+        class RecordingProvider(FakeProvider):
+            async def complete(
+                self,
+                messages: list[Message],
+                tools: list[ToolSchema] | None = None,
+                model: str | None = None,
+                json_schema: dict[str, Any] | None = None,
+            ) -> LLMResponse:
+                seen_messages.append(list(messages))
+                return await super().complete(messages, tools, model, json_schema)
+
+        feed = AuditFeed()
+        feed.publish([{"type": "invalid_json", "message": "package.json is invalid"}])
+
+        run_dir = RunDir(base=tool_context.workspace.parent / "runs")
+        event_log = EventLog(run_dir)
+        agent = BuildAgent(
+            agent_id="worker-0",
+            provider=RecordingProvider([]),
+            dispatcher=ToolDispatcher(),
+            context=tool_context,
+            event_log=event_log,
+            deadline=tool_context.deadline,
+            feed=feed,
+        )
+        await agent.run([PlanTask(id="t1", title="Build", kind="edit")], "You are a builder.")
+        event_log.close()
+
+        assert seen_messages, "provider was never called"
+        injected = [
+            m for m in seen_messages[-1] if m.role == "user" and "AUDIT ALERT" in (m.content or "")
+        ]
+        assert len(injected) == 1
+        assert "package.json is invalid" in injected[0].content
 
 
 class TestAuditAgent:


### PR DESCRIPTION
## What

Two fixes to the multi-agent build engine:

- **Audit feedback loop**: adds `AuditFeed`, a shared channel between the audit agent and build agents. The audit agent publishes findings to it (deduplicated by type + message), and each worker polls for unseen findings before its next LLM turn — a correction prompt is injected into its conversation so it can fix broken foundations mid-build. The supervisor also now includes the audit's final findings in the `supervisor.done` event instead of dropping them.
- **Transitive task partitioning**: `Supervisor._partition_tasks` now builds the full dependency graph with union-find, so transitively-connected chains (t4→t3→t2) land in a single work stream even when the tail task never directly names the head. Streams are topologically ordered (plan order as tiebreak) and merged down to `MAX_WORKERS`; dependency cycles fall back to plan order instead of hanging.

## Why

Closes the two open findings from the PR #2 code review:

- Audit findings were only written to the event log — workers kept building on broken foundations until the VERIFY phase caught it (#4).
- The partitioner only grouped direct dependents, so deep dependency chains could be split across workers, leaving one worker waiting on files another hadn't written yet (#3).

## How

- `AuditFeed` keeps a cursor per consumer, so each worker sees each finding exactly once; dedup by `(type, message)` prevents re-alerting every 20-second audit cycle for the same unresolved issue.
- `BuildAgent` gains an optional `feed` parameter and polls it right before each LLM call, emitting an `audit.feedback` event when findings are injected.
- Partitioning uses union-find over dependency edges (deps outside the task set, e.g. the completed setup task, are ignored), then a stable topological sort per stream.

## Testing

- [x] `make test` passes (148 tests, 6 new)
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] New tests added for new functionality (transitive grouping, worker cap, cycle handling, feed dedup/cursors, end-to-end injection of a finding into a worker conversation)

## Related Issues

Closes #3
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuiFDEHD39RSYL6nR4wfFf