### PR TITLE
Revival part 2 → 0.2.0: owned harness, real verification, budgets, and interview-grade docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,242 @@
+# Architecture
+
+NoScope turns a written spec + a deadline into a runnable MVP, then always hands
+back an artifact and a report. This document explains how it's built and — more
+usefully — *why* the interesting pieces are built the way they are.
+
+The design goal that drives everything: **a run must always terminate on time
+and always produce output.** No hangs, no open-ended spend, no silent failure.
+Every subsystem below is shaped by that constraint.
+
+## System overview
+
+A run is a fixed pipeline of phases. Each phase gets a slice of the timebox and
+the whole thing is driven by one wall-clock `Deadline`.
+
+```mermaid
+flowchart LR
+    spec[["spec.md<br/>(+ timebox)"]] --> PLAN
+    PLAN["PLAN<br/>5%"] --> REQUEST["REQUEST<br/>approve caps"]
+    REQUEST --> BUILD["BUILD<br/>65%"]
+    BUILD --> HARDEN["HARDEN<br/>10%"]
+    HARDEN --> VERIFY["VERIFY<br/>15%"]
+    VERIFY --> HANDOFF["HANDOFF<br/>5%"]
+    HANDOFF --> out[["artifact +<br/>handoff.md +<br/>events.jsonl"]]
+
+    PLAN -.LLM.-> llm[(LLM provider)]
+    BUILD -.parallel agents.-> llm
+    HARDEN -.repair.-> llm
+    VERIFY -.confirm.-> llm
+    HANDOFF -.report.-> llm
+```
+
+| Phase | Uses LLM? | Responsibility |
+|---|---|---|
+| **PLAN** | yes (structured output) | Spec → a validated `PlanOutput` (tasks, capabilities, acceptance plan) |
+| **REQUEST** | no | Human (or `--yes`) approves the capabilities the plan asked for |
+| **BUILD** | yes (multi-agent) | A supervisor runs parallel build agents against the plan |
+| **HARDEN** | only to repair | Run acceptance checks; auto-repair a failing one and re-run |
+| **VERIFY** | yes (agent) | Get the app running and **independently confirm** it responds |
+| **HANDOFF** | yes (cheap model) | Write the report — **always runs, even on error** |
+
+`HANDOFF` runs in a `finally`-style path so a crash mid-BUILD still yields a
+report. That's the "always produce output" guarantee in code, not just prose.
+
+## The timebox engine
+
+[`deadline.py`](noscope/deadline.py) is the spine. At construction it converts
+the total timebox into cumulative per-phase wall-clock deadlines from a fixed
+allocation (`PLAN 5% · BUILD 65% · HARDEN 10% · VERIFY 15% · HANDOFF 5%`).
+
+Everything that could run long consults it:
+
+- Agent loops check `deadline.is_expired()` / `should_transition(phase)` every
+  iteration and stop cleanly.
+- The shell tool derives each command's timeout from the time left in the phase.
+- Phases that overrun eat into later phases rather than the wall clock slipping.
+
+The deadline is *cooperative* — it doesn't kill threads, it gives every loop a
+cheap check so they wind down and the pipeline advances to HANDOFF.
+
+## Multi-agent build
+
+BUILD is the most concurrent part. The [`Supervisor`](noscope/supervisor.py)
+runs setup first, then fans out.
+
+```mermaid
+flowchart TB
+    plan[PlanOutput] --> split{split off<br/>setup task}
+    split --> setup
+    subgraph setup [Setup — parallel]
+      structure[structure agent<br/>writes files]
+      deps[deps agent<br/>installs packages]
+    end
+    setup --> partition[partition remaining tasks<br/>union-find + topo sort]
+    partition --> w0[worker 0]
+    partition --> w1[worker 1]
+    audit[audit agent] -. findings .-> feed[(AuditFeed)]
+    feed -. inject corrections .-> w0
+    feed -. inject corrections .-> w1
+    w0 --> done[all tasks marked]
+    w1 --> done
+```
+
+Three design decisions worth calling out:
+
+- **Setup is split into two cooperating agents** — one writes the project
+  files, one installs dependencies — so scaffolding and `pip install` overlap
+  instead of serializing.
+- **Task partitioning uses union-find over the dependency graph**, then a
+  topological sort within each work-stream ([`_partition_tasks`](noscope/supervisor.py)).
+  This groups *transitively* dependent tasks onto the same worker so a worker
+  never blocks on a file another worker hasn't written yet. Dependency cycles
+  fall back to plan order instead of hanging.
+- **The audit agent runs concurrently and feeds back through `AuditFeed`** — a
+  small pub/sub channel with per-consumer cursors and dedup. Findings (bad
+  JSON, missing entry point) are injected into the relevant worker's next turn
+  as a correction, rather than accumulating in a log nobody reads.
+
+Concurrency is bounded at `MAX_WORKERS = 2` — a deliberate, conservative choice
+to stay under provider rate limits with several concurrent LLM streams.
+
+## Tools and capability gating
+
+Agents don't touch the machine directly. Every action goes through a
+capability-gated [`ToolDispatcher`](noscope/tools/dispatcher.py).
+
+```mermaid
+flowchart LR
+    agent[agent] -->|tool call| dispatch[ToolDispatcher]
+    dispatch --> cap{capability<br/>granted?}
+    cap -->|no| deny[log tool.denied<br/>return error]
+    cap -->|yes| safe{safety filter<br/>+ path check}
+    safe -->|blocked| deny
+    safe -->|ok| exec[execute tool]
+    exec --> redact[redact secrets<br/>trim bulky fields]
+    redact --> log[(events.jsonl)]
+    redact --> agent
+```
+
+The tool surface is deliberately its own thing (not raw bash) so each action
+can be gated, path-checked, logged, and redacted:
+
+- **Filesystem:** `read_file` (with line windows), `write_file`,
+  **`edit_file`** (exact-string replacement with a uniqueness guard + diff),
+  `list_directory`, `create_directory`.
+- **Discovery:** `search_files` (regex/grep) and `find_files` (glob), in-process
+  and workspace-bounded.
+- **Shell:** `exec_command` with a deny-list safety filter and a
+  credential-scrubbed environment.
+- **Git:** init/status/add/commit/diff.
+
+Every path is validated against the workspace boundary; every command output is
+run through secret redaction before it reaches the log or the model's context.
+Capabilities (`WORKSPACE_RW`, `SHELL_EXEC`, `GIT`, …) are requested by the plan
+and approved in REQUEST, so the human sees exactly what the run can do before it
+does anything.
+
+## Verification: execute, don't trust
+
+This is the credibility core. The naive version — "ask the model whether the app
+works" — lets a confident model declare success on a broken build. NoScope
+verifies in two ways, both of which **run real commands**:
+
+**HARDEN** runs the spec's acceptance checks. A check passes only if the command
+exits `0` *and* (when the spec says `cmd: … ==> <text>`) the output actually
+contains `<text>`. A failing check triggers a **bounded repair**: a small fix
+agent gets the failing command and its output, edits the code, and the check is
+**re-run** — the re-run is the authority, not the agent's say-so.
+
+**VERIFY** gets the app running, then the agent must call a `confirm_running`
+tool with a command that proves it (e.g. `curl -sf localhost:5000`). The
+*harness* executes that command and accepts the verdict only if it genuinely
+passes:
+
+```mermaid
+sequenceDiagram
+    participant A as verify agent
+    participant H as VerifyPhase (harness)
+    participant S as shell
+    A->>H: confirm_running(cmd="curl -sf localhost:5000", expect="Todo")
+    H->>S: run cmd
+    S-->>H: exit code + output
+    alt exit 0 and "Todo" in output
+        H-->>A: VERIFIED (independently confirmed)
+    else
+        H-->>A: failed — here's the output, keep fixing
+    end
+```
+
+The verdict is grounded in an executed command every time. A model that asserts
+success without a passing command simply doesn't get a "verified" run.
+
+## Two budgets: time and tokens
+
+NoScope's promise is a *spend cap*. It enforces that in both dimensions:
+
+- **Wall-clock** — the `Deadline` above.
+- **Tokens** — `TokenTracker` optionally carries a budget; the build, verify,
+  and repair loops check `exceeded()` alongside the deadline and stop the same
+  way. `--token-budget` makes the cap explicit.
+
+Either limit ending the run still routes through HANDOFF, so you always get an
+artifact and a report regardless of which cap you hit.
+
+## The LLM layer
+
+[`llm/`](noscope/llm/) is a thin provider abstraction (`complete()` over a
+normalized message/tool/usage model) with Anthropic and OpenAI implementations.
+It's intentionally small so keeping up with API changes is a one-file job — a
+lesson from the fact that a single stale model default is what broke the project
+before this rework.
+
+It uses the current API surface and degrades gracefully:
+
+- **Structured outputs** — the planner's Pydantic schema is enforced via
+  `output_config.format` (Anthropic) / `response_format` (OpenAI), with a shared
+  helper that makes a Pydantic schema acceptable to structured outputs.
+- **Prompt caching** — `cache_control` breakpoints on the stable system prompt
+  and tool list, so a long agent loop pays cache-read rates instead of full
+  price on every turn. The cost summary reports what caching saved.
+- **Adaptive thinking + effort**, with a *layered fallback*: if a (usually
+  older, user-overridden) model rejects thinking/effort/structured-format, the
+  provider degrades one capability at a time and remembers the result, so it
+  pays the failed-request tax at most once per capability per run.
+- **Per-role models** — the handoff report runs on a cheaper fast model at low
+  effort; planning runs at high effort.
+- **SDK-native retries** (honoring `Retry-After`) instead of a hand-rolled loop.
+
+## Observability
+
+Every tool call, LLM response, task completion, audit finding, and phase
+transition is appended to `events.jsonl` (secret-redacted, bulky fields
+trimmed). A run directory also holds `plan.json`, `contract.json`, the
+capability grants, and `handoff.md`. The run is fully reconstructable after the
+fact from the event log — which is also what makes the "observable" claim real
+rather than aspirational.
+
+## Key design decisions
+
+| Decision | Why |
+|---|---|
+| **Own agent harness, not a wrapper over the Claude Agent SDK** | The orchestration *is* the project. Wrapping the SDK (Claude Code as a library) would make it "Claude Code with a timer" and give up provider-agnosticism. See [`PLAN.md`](PLAN.md) §3 for the full trade-off. |
+| **Execute checks, don't trust the model** | Model-as-oracle verification is the worst failure mode for a demo. HARDEN and VERIFY both ground their verdicts in commands the harness runs. |
+| **`edit_file` with a uniqueness guard, not whole-file rewrites** | Whole-file writes were the dominant token cost and caused last-write-wins clobbering; an edit that would match ambiguously *fails* rather than changing the wrong region. |
+| **Cooperative deadline, not forced cancellation** | Cheap per-loop checks wind agents down cleanly so the pipeline always reaches HANDOFF, instead of killing work mid-write. |
+| **Capability gating + dedicated tools over raw bash** | Typed, gated tools can be path-checked, approved, logged, and redacted; an opaque bash string can't. |
+| **Thin, single-file LLM layer** | Owning the harness means owning API churn; keeping the provider layer tiny makes a model/API change a one-line default, not a refactor. |
+
+## Known limitations
+
+Honest boundaries (tracked in [`PLAN.md`](PLAN.md) and [`RELEASE.md`](RELEASE.md)):
+
+- No conversation-context management yet — very long runs can approach context
+  limits.
+- The Docker sandbox uses a Python-only image; git tools still act on the host
+  tree during `--sandbox` runs, and the container exec timeout is not
+  deadline-aware.
+- `MAX_WORKERS` is fixed at 2.
+- The shell safety filter is a deny-list — a backstop, not a sandbox. Untrusted
+  specs should use `--sandbox`.
+- Live end-to-end behavior is validated by hand (see `RELEASE.md`), not in CI —
+  CI has no API key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to NoScope are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.2.0] — 2026-08
+
+A six-months-later revival: un-break the tool on today's APIs, modernize the LLM
+layer, and build out NoScope's own agent harness (rather than wrapping the
+Claude Agent SDK — the orchestration is the point). See `PLAN.md` for the full
+review and roadmap.
+
+### Fixed
+
+- **Runs out of the box again.** Default models updated to `claude-sonnet-5` /
+  `gpt-5.6-terra` (the previous `claude-sonnet-4-20250514` was retired June
+  2026, making the default run a hard API error). Defaults are pinned by a test.
+- OpenAI `stop_reason` is normalized (`stop` → `end_turn`), so the OpenAI agent
+  loop can actually terminate instead of burning iterations.
+- `advance_phase` is called for BUILD and VERIFY, so the event log stamps the
+  correct phase on tool events.
+- The planner no longer swallows API errors as "invalid plan".
+- Git subprocesses run with the sanitized environment (API keys were visible).
+- App launch is opt-in via `--serve`; by default NoScope prints the run command
+  instead of blocking on a foreground server, honoring the hard-deadline promise.
+- Docker sandbox: file writes use base64 (the old heredoc corrupted backslashes
+  and could truncate on content); all container paths are validated against
+  traversal and shell-injection.
+
+### Added
+
+- **Editing and discovery tools:** `edit_file` (exact-string replacement with a
+  uniqueness guard + diff, replacing whole-file rewrites), `search_files`
+  (regex/grep), `find_files` (glob), and `read_file` line windows.
+- **Verification that actually verifies:** acceptance checks assert expected
+  output (`cmd: <command> ==> <text>`), VERIFY confirms the app runs by having
+  the harness execute the agent's proof command (not by trusting a `VERIFIED:`
+  string), and a failing check gets a bounded auto-repair-and-retry.
+- **Token budgets:** an optional `--token-budget` spend cap that stops the build
+  the same way the timebox does — the spend guarantee is now true in tokens too.
+- **Cache-aware cost reporting:** the summary shows cached-read tokens and the
+  dollars prompt caching saved.
+- Structured outputs, prompt caching, adaptive thinking + effort, and SDK-native
+  retries in the LLM layer; a cheaper model (Haiku) for the handoff report.
+- `--serve` flag; `NOSCOPE_FAST_MODEL`, `NOSCOPE_MAX_TOKENS`, `NOSCOPE_EFFORT`,
+  `NOSCOPE_TOKEN_BUDGET` settings.
+
+### Changed
+
+- Prompts moved from ALL-CAPS imperatives to goal + constraints style.
+- All dependencies upgraded (`anthropic` 0.80 → 0.120, `openai` 2.21 → 2.53)
+  with version floors.
+- Example specs modernized (`python3`, expected-output checks) and README given
+  an honest "When to use NoScope" section.
+
+### Removed
+
+- The never-wired Textual TUI (`--tui`), unreachable panic mode, the dead
+  streaming code path, and duplicated pricing tables.
+
+## [0.1.0] — 2026-02
+
+Initial release: time-boxed autonomous agent orchestration that builds runnable
+MVPs from written specs.

--- a/PLAN.md
+++ b/PLAN.md
@@ -230,12 +230,14 @@ are reliable enough to demo. Every tool is ours, tested, and capability-gated.
 Goal: replace model-as-oracle with independent checks — this is the credibility
 core of "you always get a runnable artifact," and the most demo-visible upgrade.
 
-- [ ] Acceptance checks: keep `cmd:` checks but add expected-output assertions
-      (`cmd: ... expect: <substring|status>`); run them from code, not prompts.
-- [ ] Replace the `VERIFIED:` sentinel-string protocol with a structured
-      verdict (structured output schema: status, evidence, failures) from a
-      fresh-context verifier that did not build the code. (Structured outputs
-      from Phase 1 make this clean.)
+- [x] Acceptance checks: `cmd:` checks now assert expected output
+      (`cmd: <command> ==> <substring>` and a plan `expect_output` field); run
+      from code in HARDEN, not prompts. Exit-0 alone no longer counts as a pass.
+- [x] Replace the `VERIFIED:` sentinel-string protocol with independent
+      confirmation: the verify agent proposes a proof command via a
+      `confirm_running` tool and the harness runs it, accepting the verdict only
+      if it really passes. (Stronger than a self-reported structured verdict —
+      the check is executed, not asserted.)
 - [ ] HARDEN gains a bounded repair loop (budgeted by the phase deadline):
       failing check → targeted fix session → re-run check.
 - [ ] Turn the audit agent into a real checker: run lint/build/import checks

--- a/PLAN.md
+++ b/PLAN.md
@@ -122,41 +122,38 @@ alerts.
 
 ## 3. Strategic decision
 
-**Rebuild the execution layer on the Claude Agent SDK; keep NoScope as the
-product layer.**
+**Build out NoScope's own agent harness. Do not wrap the Claude Agent SDK.**
 
-The Claude Agent SDK (`claude-agent-sdk`) ships the harness NoScope hand-rolls
-today: the agent loop, built-in Read/Write/**Edit**/Bash/Glob/Grep/WebSearch
-tools, context management/compaction, subagents, hooks, and a permission
-system. Rebuilding on it means:
+NoScope's purpose is to be a compelling, self-contained demonstration of
+time-boxed autonomous AI — a way to learn agent orchestration, show it off, and
+run quick "sculpt" POCs. That purpose is the deciding factor.
 
-- NoScope's ~2,000 lines of loop/tools/provider plumbing (agents.py,
-  supervisor worker loop, tools/filesystem, tools/shell duplication, the
-  streaming dead code) shrink to configuration + hooks.
-- We inherit an edit tool, search tools, and context management on day one —
-  three of our biggest capability gaps — for free.
-- Every future model/API change (new model IDs, thinking semantics, caching)
-  is absorbed by the SDK instead of by us. The last six months proved we do
-  not keep up by hand.
+The rejected alternative was to rebuild the execution layer on the Claude Agent
+SDK (Claude Code packaged as a library). It would have made builds more reliable
+with less code to maintain — but the Claude Agent SDK *is* Claude Code, so
+NoScope would become "Claude Code with a timer and a permission prompt." For a
+tool whose value is the orchestration itself, that guts the point: if it's a
+thin wrapper, people can just use Claude Code. It's also Anthropic-only, which
+would kill the provider-agnostic story.
 
-**What NoScope keeps and owns (the differentiated layer):**
+So the harness stays hand-rolled and owned — the agent loop, the tool registry,
+the multi-agent supervisor, the provider abstraction. The work ahead is to make
+that harness genuinely good rather than to outsource it:
 
-- `Deadline` — wall-clock timebox with phase budgets, driving cancellation.
-- **Capability model** → reimplemented as SDK permission hooks (approve/deny
-  per tool class), which is strictly stronger than today's coarse gate.
-- **Spec format + contract** — unchanged; it holds up well.
-- **Event log** → fed from SDK hooks, with per-call token/cost attribution
-  added (today we only log a grand total).
-- **Phases + handoff report** — the run lifecycle and the always-produced
-  artifact/report remain the product.
+- Close the capability gaps that make builds unreliable (editing, search,
+  real verification) with our own well-tested tools.
+- Keep the provider abstraction (Anthropic + OpenAI) as a real feature.
+- Own the model/API churn deliberately — Phase 1 already showed it's tractable
+  (structured outputs, caching, thinking, SDK-native retries) when the LLM
+  layer is small and well-factored.
 
-**Trade-off accepted:** the SDK is Anthropic-only. The OpenAI provider is
-demoted from "co-equal backend" to "not in v0.2" (see §5). Keeping true
-provider parity means continuing to own a bespoke harness forever — that cost
-is what killed the last six months. If provider-agnosticism turns out to be a
-real adoption requirement, the fallback design is the Anthropic *tool runner*
-+ OpenAI Responses API behind our existing provider protocol — but not for the
-next release.
+**What this costs us, honestly:** we keep maintaining the harness, and we chase
+model/API changes ourselves (the thing that rotted the project the first time).
+Phase 1's changes are the mitigation — a thin, well-tested LLM layer where a
+model swap is a one-line default and the modern features degrade gracefully.
+The differentiators from §1 (timebox engine, capability/approval model, spec
+contract, event log, guaranteed handoff) all stay, and now they sit on a
+harness we can actually demo and explain.
 
 ## 4. Roadmap
 
@@ -206,49 +203,46 @@ survives the Phase 2 re-architecture (planner, prompts, verification design).
 - [x] SDK-native retries (`max_retries`, honors `Retry-After`, covers
       429/5xx/timeouts) replace the hand-rolled loop. Dead `stream()` path removed.
 
-### Phase 2 — Re-architecture on the Claude Agent SDK
+### Phase 2 — Build out the owned harness (capability gaps)
 
-Goal: NoScope becomes the timebox/capability/contract harness around SDK-run
-agents.
+Goal: give NoScope's own agents the tools a credible harness needs, so builds
+are reliable enough to demo. Every tool is ours, tested, and capability-gated.
 
-- [ ] Replace `BuildAgent`/tool dispatcher internals with `claude-agent-sdk`
-      `query()` sessions: one session per work stream, system prompt from our
-      phase templates, cwd = workspace.
-- [ ] Capabilities → SDK permission hooks: `WORKSPACE_RW`/`SHELL_EXEC`/`GIT`
-      map to tool allow/deny lists; `--danger` maps to permissive mode; the
-      REQUEST phase approves the hook policy instead of a homegrown gate.
-- [ ] Deadline → session control: cancel sessions at phase boundaries; inject
-      time-remaining via hook-driven system reminders instead of fake user
-      turns.
-- [ ] Event log → SDK hooks (tool-use pre/post), keeping our JSONL format and
-      redaction, now with correct phases and per-call usage.
-- [ ] Supervisor keeps task partitioning (union-find + topo sort — recent, keep)
-      but delegates execution; audit agent becomes a real checker (run
-      lint/build/import checks via a cheap model session, feed findings back —
-      the AuditFeed mechanism from Aug 2026 carries over).
-- [ ] Retire: hand-rolled filesystem/shell tools (SDK built-ins + our
-      permission hooks), the custom Docker tool layer (prefer: run the whole
-      NoScope process inside a container; document `--sandbox` as
-      containerized-run rather than per-tool `docker cp` choreography).
-- [ ] Decide OpenAI provider fate explicitly in CHANGELOG (park with warning,
-      or delete).
+- [x] `edit_file` — exact-string replacement with a uniqueness guard and a
+      returned diff, replacing whole-file rewrites for edits. Mutations now run
+      sequentially so same-file edits can't race.
+- [ ] Search + discovery tools: `search_files` (regex/grep across the tree) and
+      `find_files` (glob) so agents stop discovering code one `list_directory`
+      at a time.
+- [ ] Partial reads: `read_file` gains optional line `offset`/`limit` so large
+      files don't dump whole into context.
+- [ ] Docker sandbox correctness (from §2.3/§2.4): fix the heredoc write
+      corruption and path injection, validate paths, use an image with the
+      toolchain the plan actually needs (or document Python-only), and keep git
+      operating on the real tree. Or replace per-tool `docker cp` choreography
+      with running the whole NoScope process in a container.
+- [ ] Context management: cap/summarize the ever-growing agent history and the
+      50 KB shell dumps so long runs don't die on context length.
+- [ ] Make `MAX_WORKERS` configurable rather than a hardcoded rate-limit posture.
 
 ### Phase 3 — Verification that actually verifies
 
 Goal: replace model-as-oracle with independent checks — this is the credibility
-core of "you always get a runnable artifact."
+core of "you always get a runnable artifact," and the most demo-visible upgrade.
 
 - [ ] Acceptance checks: keep `cmd:` checks but add expected-output assertions
       (`cmd: ... expect: <substring|status>`); run them from code, not prompts.
 - [ ] Replace the `VERIFIED:` sentinel-string protocol with a structured
       verdict (structured output schema: status, evidence, failures) from a
-      fresh-context verifier session that did not build the code.
+      fresh-context verifier that did not build the code. (Structured outputs
+      from Phase 1 make this clean.)
 - [ ] HARDEN gains a bounded repair loop (budgeted by the phase deadline):
       failing check → targeted fix session → re-run check.
-- [ ] Task completion requires evidence: `mark_task_complete` accepts a claim
-      that the audit checker can spot-verify against the workspace.
+- [ ] Turn the audit agent into a real checker: run lint/build/import checks
+      via the cheap fast model and feed findings back through the existing
+      `AuditFeed`; task completion accepts a claim the checker can spot-verify.
 - [ ] Adopt API task budgets (`output_config.task_budget`) so agents pace to a
-      token budget the same way the Deadline paces wall-clock — the two
+      token budget the same way the `Deadline` paces wall-clock — the two
       budgets are the product's core promise, now enforced in both dimensions.
 
 ### Phase 4 — Release readiness
@@ -266,12 +260,12 @@ core of "you always get a runnable artifact."
 
 | Item | Decision |
 |---|---|
-| Textual TUI (`ui/tui.py`, `--tui`) | Delete. Never wired up; Rich console is sufficient. |
-| Panic mode | Delete or implement in the Deadline→session cancellation path; no half-state. |
-| OpenAI provider | Park in Phase 2 (warning + known-broken list) — revisit only if adoption demands it. |
-| Per-tool Docker choreography (`tools/docker.py`) | Replace with containerized-process sandboxing. |
+| Textual TUI (`ui/tui.py`, `--tui`) | Deleted in Phase 0. Never wired up; Rich console is sufficient. |
+| Panic mode | Deleted in Phase 0. Revisit only if the timebox UX needs an explicit end-game state. |
+| OpenAI provider | **Keep** — provider-agnosticism is a real feature under the owned-harness direction (§3). Modernized in Phase 1. |
+| Per-tool Docker choreography (`tools/docker.py`) | Fix in place (Phase 2) or replace with containerized-process sandboxing; do not ship it broken. |
 | `risk_policy`, `repo_mode`, `secrets:` grants | Delete from spec schema until a phase actually consumes them. |
-| Hand-rolled retries, `stream()` dead code, duplicate pricing tables | Delete in Phases 0–1. |
+| Hand-rolled retries, `stream()` dead code, duplicate pricing tables | Deleted in Phases 0–1. |
 
 ## 6. Success criteria for "worth releasing"
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -182,7 +182,7 @@ Goal: `main` runs again on today's APIs. No re-architecture.
 ### Phase 1 — Modernize the LLM usage (still current architecture)
 
 Goal: the existing loop stops leaving free wins on the table. Everything here
-survives the Phase 2 re-architecture (planner, prompts, verification design).
+carries into the later phases (planner, prompts, verification design).
 
 - [x] Planner: structured outputs (`output_config.format` from
       `PlanOutput.model_json_schema()`, prepared with `additionalProperties:
@@ -211,10 +211,10 @@ are reliable enough to demo. Every tool is ours, tested, and capability-gated.
 - [x] `edit_file` — exact-string replacement with a uniqueness guard and a
       returned diff, replacing whole-file rewrites for edits. Mutations now run
       sequentially so same-file edits can't race.
-- [ ] Search + discovery tools: `search_files` (regex/grep across the tree) and
+- [x] Search + discovery tools: `search_files` (regex/grep across the tree) and
       `find_files` (glob) so agents stop discovering code one `list_directory`
       at a time.
-- [ ] Partial reads: `read_file` gains optional line `offset`/`limit` so large
+- [x] Partial reads: `read_file` gains optional line `offset`/`limit` so large
       files don't dump whole into context.
 - [ ] Docker sandbox correctness (from §2.3/§2.4): fix the heredoc write
       corruption and path injection, validate paths, use an image with the

--- a/PLAN.md
+++ b/PLAN.md
@@ -238,7 +238,7 @@ core of "you always get a runnable artifact," and the most demo-visible upgrade.
       `confirm_running` tool and the harness runs it, accepting the verdict only
       if it really passes. (Stronger than a self-reported structured verdict —
       the check is executed, not asserted.)
-- [ ] HARDEN gains a bounded repair loop (budgeted by the phase deadline):
+- [x] HARDEN gains a bounded repair loop (budgeted by the phase deadline):
       failing check → targeted fix session → re-run check.
 - [ ] Turn the audit agent into a real checker: run lint/build/import checks
       via the cheap fast model and feed findings back through the existing

--- a/PLAN.md
+++ b/PLAN.md
@@ -249,14 +249,17 @@ core of "you always get a runnable artifact," and the most demo-visible upgrade.
 
 ### Phase 4 — Release readiness
 
-- [ ] Positioning rewrite in README: "timebox as spend cap + capability gating
-      + auditable one-shot runs" vs. interactive agents (Claude Code) and
-      open-ended cloud agents (Devin) — with honest "when NOT to use NoScope".
-- [ ] Real cost reporting (cached vs. uncached, per phase, per agent) — make
-      the cost-control pitch demonstrable in the handoff report.
-- [ ] Fresh example specs that exercise current stacks; CI smoke test that
-      runs a 3-minute spec end-to-end against the live API (nightly, keyed).
-- [ ] Version 0.2.0, CHANGELOG, and a release checklist.
+- [x] Positioning: README "When to use NoScope" section — POC-from-spec with a
+      spend cap and audit trail vs. interactive agents (Claude Code/Cursor) and
+      open-ended cloud agents (Devin), with an honest "reach for something else
+      when".
+- [x] Real cost reporting: cached vs. uncached tokens and dollars-saved in the
+      final summary; token totals (incl. cache) in the `run.complete` event.
+      (Per-phase/per-agent attribution not yet broken out.)
+- [x] Fresh example specs on current stacks (`python3`, expected-output checks).
+      A live end-to-end smoke test is documented in `RELEASE.md` (manual — no
+      API key in CI); a keyed nightly CI job is still open.
+- [x] Version 0.2.0, `CHANGELOG.md`, and a `RELEASE.md` checklist.
 
 ## 5. Explicit cuts
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@
 
 NoScope takes a written specification, a fixed time limit, and explicit capability grants, then autonomously plans, builds, and validates a working software prototype. When the timer runs out, you always get a runnable artifact and a handoff report — never a hanging process or a surprise bill.
 
+> **Deep dives:** [`ARCHITECTURE.md`](ARCHITECTURE.md) — how it works and why (with diagrams) · [`PLAN.md`](PLAN.md) — the design audit and the build-our-own-harness-vs-wrap-the-SDK decision · [`CHANGELOG.md`](CHANGELOG.md)
+
 ---
 
 ## Why NoScope?
 
-40% of agentic AI projects get cancelled due to cost overruns. NoScope's timebox is a spend-cap guarantee — when time's up, you get a result, not a bill.
+Gartner projects that [over 40% of agentic AI projects will be scrapped by 2027](https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027), citing cost and unclear value among the causes. NoScope's timebox is a spend-cap guarantee — when time's up, you get a result, not a bill.
 
 | | Traditional Agent | NoScope |
 |---|---|---|
@@ -125,6 +127,43 @@ The **HANDOFF** phase always runs, even if the build fails — you always get a 
 
 ---
 
+## Design highlights
+
+The interesting engineering is in how the "always terminate, always produce
+output" guarantee is enforced. A few decisions worth a closer look
+([`ARCHITECTURE.md`](ARCHITECTURE.md) has the full picture):
+
+- **Verification executes, it doesn't trust.** The failure mode to avoid is a
+  confident model declaring success on a broken build. HARDEN passes a check
+  only if the command *actually* exits 0 and its output matches; VERIFY makes
+  the agent propose a proof command (`curl -sf localhost:5000`) and the harness
+  *runs it* — the verdict is grounded in a real command every time. A failing
+  check triggers a bounded auto-repair, then re-runs.
+
+- **Two spend caps: time and tokens.** A cooperative wall-clock `Deadline`
+  gives every agent loop a cheap per-iteration check so it winds down and the
+  pipeline still reaches HANDOFF; an optional `--token-budget` caps spend in
+  tokens the same way. The product's promise is a spend guarantee — enforced in
+  both dimensions.
+
+- **Parallel build with dependency-aware partitioning.** A supervisor splits
+  setup into concurrent structure + deps agents, then partitions the remaining
+  tasks with union-find over the dependency graph (+ topological sort) so
+  transitively-dependent work lands on one worker and cycles can't hang. A
+  concurrent audit agent feeds corrections back into workers mid-build.
+
+- **Capability-gated, typed tools over raw bash.** Every action is a typed tool
+  that can be permission-gated, path-checked against the workspace, logged, and
+  secret-redacted — including an `edit_file` whose uniqueness guard *fails* on
+  an ambiguous match instead of editing the wrong region.
+
+- **A thin, modern LLM layer.** Structured outputs, prompt caching (with
+  cache-savings reporting), adaptive thinking/effort with graceful degradation,
+  and SDK-native retries — kept small on purpose so a model/API change is a
+  one-line default, not a refactor.
+
+---
+
 ## Spec Format
 
 Write your spec as Markdown with YAML frontmatter:
@@ -208,6 +247,21 @@ Every run produces a structured output in `.noscope/runs/<run_id>/`:
   capabilities_grant.json   # What capabilities were approved
   handoff.md                # Final report (always generated, even on failure)
 ```
+
+The **event log** is append-only JSONL — every action is reconstructable after
+the fact (secrets redacted, bulky fields trimmed):
+
+```jsonl
+{"ts":"2026-08-06T18:22:01Z","phase":"BUILD","seq":42,"type":"tool.write_file","summary":"Calling write_file","data":{"tool":"write_file","args":{"path":"app.py"}}}
+{"ts":"2026-08-06T18:22:07Z","phase":"BUILD","seq":58,"type":"task.complete","summary":"[worker-0] Task t2: CRUD endpoints","data":{"task_id":"t2","agent_id":"worker-0"}}
+{"ts":"2026-08-06T18:23:14Z","phase":"HARDEN","seq":71,"type":"acceptance.check","summary":"✓ cmd: python3 -c 'import app'","result":{"passed":true,"reason":""}}
+{"ts":"2026-08-06T18:23:40Z","phase":"VERIFY","seq":80,"type":"verify.pass","summary":"MVP verified (independently confirmed): responds on / with the todo list"}
+```
+
+The **handoff report** (`handoff.md`) is written even if the build fails — it
+records the contract, what was built, exact run commands, the pass/fail table,
+and known gaps. See the [Run Outputs section of `ARCHITECTURE.md`](ARCHITECTURE.md#observability)
+for the full model.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ NoScope takes a written specification, a fixed time limit, and explicit capabili
 
 ---
 
+## When to use NoScope
+
+NoScope is a **time-boxed proof-of-concept builder** — it turns a written spec
+into a runnable MVP inside a fixed budget, then hands you the artifact, a
+verification verdict, and a full event log. It's built to demonstrate what
+autonomous agents can do and to sculpt quick prototypes.
+
+**Reach for NoScope when** you want a runnable POC from a spec with a hard
+spend cap, an auditable record of every action, and an explicit permission
+gate — a self-contained, one-shot "spec in, MVP out" run.
+
+**Reach for something else when** you want to pair interactively on a codebase
+(use [Claude Code](https://claude.com/claude-code) or Cursor), or you want an
+open-ended cloud agent to own a ticket end-to-end (use a Devin-style agent).
+NoScope is deliberately one-shot and time-boxed; it is not an interactive
+editor or a long-running autonomous engineer.
+
+---
+
 ## Quick Start
 
 ### Installation
@@ -118,8 +137,8 @@ constraints:
   - "Use Flask or FastAPI"
   - "Use SQLite for storage"
 acceptance:
-  - "cmd: pip install -r requirements.txt"
-  - "cmd: python -c 'import app'"
+  - "cmd: python3 -m pip install -r requirements.txt"
+  - "cmd: python3 -c 'import app'"
   - "API supports CRUD operations for todos"
 ---
 
@@ -128,6 +147,24 @@ acceptance:
 Build a REST API for managing todo items with CRUD endpoints,
 SQLite persistence, and JSON request/response format.
 ```
+
+### Acceptance checks
+
+Each `acceptance` entry is either a `cmd:` check (run in the HARDEN phase) or a
+plain-language note (recorded in the handoff, not executed).
+
+- `cmd: <command>` — passes when the command exits `0`.
+- `cmd: <command> ==> <text>` — passes only when the command exits `0` **and**
+  its output contains `<text>`, so the check asserts real behavior rather than
+  just "the process started". For example:
+
+  ```yaml
+  acceptance:
+    - "cmd: python3 calc.py add 2 3 ==> 5"
+  ```
+
+If a `cmd:` check fails, HARDEN makes a bounded attempt to fix the cause and
+re-runs it before recording the result.
 
 See the [`examples/`](examples/) directory for more spec templates.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,42 @@
+# Release checklist
+
+Steps to cut a NoScope release.
+
+## Pre-flight
+
+- [ ] `uv run pytest tests/ -v` — all green
+- [ ] `uv run ruff check noscope/ tests/` and `uv run ruff format --check noscope/ tests/`
+- [ ] `uv run mypy noscope/` — clean
+- [ ] `uv run noscope doctor` — environment checks pass
+- [ ] Version bumped in `pyproject.toml` **and** `noscope/__init__.py` (they must match)
+- [ ] `CHANGELOG.md` has a dated entry for this version
+- [ ] Live smoke test with a real key (below)
+
+## Live smoke test
+
+Not covered by CI (no API key in CI). Run once before tagging:
+
+```bash
+export NOSCOPE_ANTHROPIC_API_KEY=sk-ant-...
+uv run noscope run --spec examples/cli-calculator.md --time 5m --dir /tmp/noscope-smoke --yes
+```
+
+Confirm: it completes within the timebox, HARDEN checks pass (the calculator
+spec asserts `... ==> 5`), VERIFY reports an independently-confirmed verdict,
+and the final summary shows a cost (and cache savings on Anthropic).
+
+## Tag and publish
+
+- [ ] Commit the version bump + changelog
+- [ ] `git tag v<version>` and push the tag
+
+## Known limitations to weigh before a "1.0" claim
+
+These are tracked in `PLAN.md` and are acceptable for a 0.2.x preview, not for a
+stability guarantee:
+
+- No conversation-context management yet — very long runs can hit context limits.
+- `--sandbox` (Docker) uses a Python-only image; git tools still act on the host
+  tree during sandbox runs, and the exec timeout is not deadline-aware.
+- `MAX_WORKERS` is fixed at 2.
+- Live end-to-end behavior is validated by hand, not in CI.

--- a/examples/cli-calculator.md
+++ b/examples/cli-calculator.md
@@ -6,8 +6,8 @@ constraints:
   - "No external dependencies"
   - "Command-line interface"
 acceptance:
-  - "cmd: python calc.py add 2 3"
-  - "cmd: python calc.py multiply 4 5"
+  - "cmd: python3 calc.py add 2 3 ==> 5"
+  - "cmd: python3 calc.py multiply 4 5 ==> 20"
   - "Handles basic error cases"
 ---
 

--- a/examples/hello-flask.md
+++ b/examples/hello-flask.md
@@ -6,7 +6,7 @@ constraints:
   - "Python only"
   - "No database needed"
 acceptance:
-  - "cmd: pip install -r requirements.txt && python -c \"import app\""
+  - "cmd: python3 -m pip install -r requirements.txt && python3 -c \"import app\""
   - "Server has a / route that returns HTML"
 ---
 

--- a/examples/static-portfolio.md
+++ b/examples/static-portfolio.md
@@ -8,6 +8,7 @@ constraints:
 acceptance:
   - "cmd: test -f index.html"
   - "cmd: test -f style.css"
+  - "cmd: grep -qi \"<!doctype html>\" index.html"
   - "Page has proper HTML5 structure"
 ---
 

--- a/examples/todo-api.md
+++ b/examples/todo-api.md
@@ -6,8 +6,8 @@ constraints:
   - "Use SQLite for storage"
   - "REST API only, no frontend"
 acceptance:
-  - "cmd: pip install -r requirements.txt"
-  - "cmd: python -c \"import app\""
+  - "cmd: python3 -m pip install -r requirements.txt"
+  - "cmd: python3 -c \"import app\""
   - "API supports CRUD operations for todos"
 ---
 

--- a/noscope/__init__.py
+++ b/noscope/__init__.py
@@ -1,3 +1,3 @@
 """NoScope — Time-boxed autonomous agent orchestration."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -239,7 +239,7 @@ class BuildAgent:
         for tc in tool_calls:
             if tc.name == "mark_task_complete":
                 virtual_calls.append(tc)
-            elif tc.name in ("read_file", "list_directory"):
+            elif tc.name in ("read_file", "list_directory", "search_files", "find_files"):
                 read_calls.append(tc)
             else:
                 # write_file, edit_file, create_directory, shell, git, ...

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -225,21 +225,25 @@ class BuildAgent:
         tool_calls: list[ToolCall],
         task_map: dict[str, PlanTask],
     ) -> list[Message]:
-        """Execute tool calls with file ops in parallel, shell commands sequential."""
+        """Execute tool calls: read-only file ops in parallel, mutations and
+        shell sequentially so same-file edits and dependent commands don't race."""
         results: list[Message] = []
 
-        # Separate virtual, file, and shell calls
+        # Read-only file ops are safe to run concurrently; mutations are not
+        # (edit_file is read-modify-write, so two edits to one file could lose
+        # a change), and shell commands may depend on each other.
         virtual_calls: list[ToolCall] = []
-        file_calls: list[ToolCall] = []
-        shell_calls: list[ToolCall] = []
+        read_calls: list[ToolCall] = []
+        sequential_calls: list[ToolCall] = []
 
         for tc in tool_calls:
             if tc.name == "mark_task_complete":
                 virtual_calls.append(tc)
-            elif tc.name in ("write_file", "read_file", "list_directory", "create_directory"):
-                file_calls.append(tc)
+            elif tc.name in ("read_file", "list_directory"):
+                read_calls.append(tc)
             else:
-                shell_calls.append(tc)
+                # write_file, edit_file, create_directory, shell, git, ...
+                sequential_calls.append(tc)
 
         # Handle virtual calls immediately
         for tc in virtual_calls:
@@ -266,14 +270,13 @@ class BuildAgent:
                     Message(role="tool", content=f"Unknown task ID: {task_id}", tool_call_id=tc.id)
                 )
 
-        # Execute file operations in parallel
-        if file_calls:
-            file_coros = [self._dispatch_and_wrap(tc) for tc in file_calls]
-            file_results = await asyncio.gather(*file_coros)
-            results.extend(file_results)
+        # Execute read-only file operations in parallel
+        if read_calls:
+            read_coros = [self._dispatch_and_wrap(tc) for tc in read_calls]
+            results.extend(await asyncio.gather(*read_coros))
 
-        # Execute shell commands sequentially (they may depend on each other)
-        for tc in shell_calls:
+        # Execute mutations and shell commands sequentially
+        for tc in sequential_calls:
             if self.ui:
                 self.ui.tool_activity(tc.name, tool_summary(tc.name, tc.arguments), self.deadline)
             result = await self.dispatcher.dispatch(tc.name, tc.arguments, self.context)

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -136,6 +136,15 @@ class BuildAgent:
         for _iteration in range(MAX_AGENT_ITERATIONS):
             if self.deadline.is_expired() or self.deadline.should_transition(Phase.BUILD):
                 break
+            # Token spend cap — stop like a deadline so the run still hands off.
+            if self.tokens is not None and self.tokens.exceeded():
+                self.event_log.emit(
+                    phase=Phase.BUILD.value,
+                    event_type="budget.exceeded",
+                    summary=f"[{self.agent_id}] Token budget reached — stopping",
+                    data={"agent_id": self.agent_id},
+                )
+                break
 
             # Check if all assigned tasks are done (skip check if no tasks assigned)
             if tasks and all(t.completed for t in tasks):

--- a/noscope/cli.py
+++ b/noscope/cli.py
@@ -37,6 +37,9 @@ def run(
     serve: bool = typer.Option(
         False, "--serve", help="After a verified build, launch the app (blocks until Ctrl+C)"
     ),
+    token_budget: int = typer.Option(
+        None, "--token-budget", help="Stop the build once this many total tokens are used"
+    ),
 ) -> None:
     """Build an MVP from a spec within a timebox."""
     from noscope.config.settings import load_settings
@@ -52,6 +55,7 @@ def run(
             default_provider=provider,
             default_model=model,
             danger_mode=danger,
+            token_budget=token_budget,
         )
     except ValueError as e:
         console.print(f"[red]Configuration error:[/red] {e}")
@@ -136,6 +140,9 @@ def new(
     ),
     serve: bool = typer.Option(
         False, "--serve", help="After a verified build, launch the app (blocks until Ctrl+C)"
+    ),
+    token_budget: int = typer.Option(
+        None, "--token-budget", help="Stop the build once this many total tokens are used"
     ),
 ) -> None:
     """Create a new project interactively and start building immediately."""
@@ -235,6 +242,7 @@ acceptance:
             default_provider=provider,
             default_model=model,
             danger_mode=danger,
+            token_budget=token_budget,
         )
     except ValueError as e:
         console.print(f"[red]Configuration error:[/red] {e}")

--- a/noscope/config/settings.py
+++ b/noscope/config/settings.py
@@ -23,6 +23,8 @@ class NoscopeSettings(BaseSettings):
     fast_model: str | None = "claude-haiku-4-5"
     max_tokens: int = 8192
     effort: str = "high"
+    # Optional total-token spend cap for a run (a peer to the timebox); None = no cap.
+    token_budget: int | None = None
     default_timebox: str = "30m"
     danger_mode: bool = False
 

--- a/noscope/llm/base.py
+++ b/noscope/llm/base.py
@@ -36,10 +36,17 @@ class ToolSchema:
 
 @dataclass
 class Usage:
-    """Token usage."""
+    """Token usage for one call.
+
+    ``input_tokens`` is the uncached prompt remainder; cached prompt tokens are
+    reported separately so cost can credit the cache. Total prompt tokens =
+    ``input_tokens + cache_creation_input_tokens + cache_read_input_tokens``.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
 
 
 @dataclass

--- a/noscope/llm/providers/anthropic.py
+++ b/noscope/llm/providers/anthropic.py
@@ -94,6 +94,11 @@ class AnthropicProvider:
             usage=Usage(
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
+                cache_creation_input_tokens=getattr(
+                    response.usage, "cache_creation_input_tokens", 0
+                )
+                or 0,
+                cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
             ),
             stop_reason=response.stop_reason or "",
         )

--- a/noscope/llm/providers/openai.py
+++ b/noscope/llm/providers/openai.py
@@ -80,9 +80,15 @@ class OpenAIProvider:
 
         usage = Usage()
         if response.usage:
+            # OpenAI reports cached prompt tokens inside prompt_tokens (not in
+            # addition to it), so subtract them out to mirror Anthropic's
+            # "input_tokens is the uncached remainder" convention.
+            details = getattr(response.usage, "prompt_tokens_details", None)
+            cached = getattr(details, "cached_tokens", 0) or 0 if details else 0
             usage = Usage(
-                input_tokens=response.usage.prompt_tokens,
+                input_tokens=max(0, response.usage.prompt_tokens - cached),
                 output_tokens=response.usage.completion_tokens,
+                cache_read_input_tokens=cached,
             )
 
         finish_reason = choice.finish_reason or ""

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -286,6 +286,8 @@ class Orchestrator:
                 event_log,
                 deadline,
                 ui=self.ui,
+                provider=self.provider,
+                tokens=tokens,
             )
             self.ui.acceptance_results(acceptance_results)
 

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -38,6 +38,7 @@ from noscope.tools.docker import (
 )
 from noscope.tools.filesystem import (
     CreateDirectoryTool,
+    EditFileTool,
     ListDirectoryTool,
     ReadFileTool,
     WriteFileTool,
@@ -186,6 +187,7 @@ class Orchestrator:
                 [
                     ReadFileTool(),
                     WriteFileTool(),
+                    EditFileTool(),
                     ListDirectoryTool(),
                     CreateDirectoryTool(),
                     ShellTool(),

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -111,8 +111,8 @@ class Orchestrator:
         serve: bool = False,
     ) -> Path:
         """Execute a full NoScope run. Returns the run directory path."""
-        # Token tracking for cost calculation
-        tokens = TokenTracker()
+        # Token tracking for cost calculation, with an optional spend cap.
+        tokens = TokenTracker(budget=self.settings.token_budget)
 
         # 1. Parse spec — from file or pre-built SpecInput
         if spec_input is not None:
@@ -403,6 +403,7 @@ class Orchestrator:
             model=self._model,
             cache_creation_tokens=tokens.cache_creation_input_tokens,
             cache_read_tokens=tokens.cache_read_input_tokens,
+            token_budget=tokens.budget,
         )
 
         # 12. LAUNCH — only with --serve does NoScope keep a process running

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -369,6 +369,8 @@ class Orchestrator:
                 "run_dir": str(run_dir.path),
                 "input_tokens": tokens.input_tokens,
                 "output_tokens": tokens.output_tokens,
+                "cache_creation_input_tokens": tokens.cache_creation_input_tokens,
+                "cache_read_input_tokens": tokens.cache_read_input_tokens,
             },
         )
         event_log.close()
@@ -399,6 +401,8 @@ class Orchestrator:
             output_tokens=tokens.output_tokens,
             provider=provider_name,
             model=self._model,
+            cache_creation_tokens=tokens.cache_creation_input_tokens,
+            cache_read_tokens=tokens.cache_read_input_tokens,
         )
 
         # 12. LAUNCH — only with --serve does NoScope keep a process running

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -50,6 +50,7 @@ from noscope.tools.git import (
     GitInitTool,
     GitStatusTool,
 )
+from noscope.tools.search import FindFilesTool, SearchFilesTool
 from noscope.tools.shell import ShellTool, build_execution_env
 from noscope.ui.console import ConsoleUI
 
@@ -190,6 +191,8 @@ class Orchestrator:
                     EditFileTool(),
                     ListDirectoryTool(),
                     CreateDirectoryTool(),
+                    SearchFilesTool(),
+                    FindFilesTool(),
                     ShellTool(),
                     GitInitTool(),
                     GitStatusTool(),

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -31,10 +31,14 @@ class TokenTracker:
     def __init__(self) -> None:
         self.input_tokens = 0
         self.output_tokens = 0
+        self.cache_creation_input_tokens = 0
+        self.cache_read_input_tokens = 0
 
     def add(self, usage: Usage) -> None:
         self.input_tokens += usage.input_tokens
         self.output_tokens += usage.output_tokens
+        self.cache_creation_input_tokens += usage.cache_creation_input_tokens
+        self.cache_read_input_tokens += usage.cache_read_input_tokens
 
 
 class PlanPhase:

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -26,19 +26,38 @@ MAX_VERIFY_ITERATIONS = 50
 
 
 class TokenTracker:
-    """Accumulates token usage across all LLM calls."""
+    """Accumulates token usage across all LLM calls.
 
-    def __init__(self) -> None:
+    An optional ``budget`` (total tokens) turns the tracker into a spend cap:
+    once total usage reaches the budget, ``exceeded()`` is true and the agent
+    loops stop — the token analog of the wall-clock deadline.
+    """
+
+    def __init__(self, budget: int | None = None) -> None:
         self.input_tokens = 0
         self.output_tokens = 0
         self.cache_creation_input_tokens = 0
         self.cache_read_input_tokens = 0
+        self.budget = budget
 
     def add(self, usage: Usage) -> None:
         self.input_tokens += usage.input_tokens
         self.output_tokens += usage.output_tokens
         self.cache_creation_input_tokens += usage.cache_creation_input_tokens
         self.cache_read_input_tokens += usage.cache_read_input_tokens
+
+    def total(self) -> int:
+        """All tokens processed (prompt, cached, and output)."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+        )
+
+    def exceeded(self) -> bool:
+        """True once a budget is set and total usage has reached it."""
+        return self.budget is not None and self.total() >= self.budget
 
 
 class PlanPhase:
@@ -288,6 +307,8 @@ the harness re-runs it after you finish.
         for _i in range(MAX_REPAIR_ITERATIONS):
             if deadline.is_expired() or deadline.should_transition(Phase.HARDEN):
                 return
+            if tokens is not None and tokens.exceeded():
+                return
             response = await provider.complete(messages, tools=tool_schemas, effort="medium")
             if tokens:
                 tokens.add(response.usage)
@@ -386,6 +407,8 @@ the blocker instead of looping.
         for _i in range(MAX_VERIFY_ITERATIONS):
             if deadline.is_expired():
                 return self._fail(event_log, "Deadline expired during verification")
+            if tokens is not None and tokens.exceeded():
+                return self._fail(event_log, "Token budget reached during verification")
 
             response = await provider.complete(messages, tools=tool_schemas)
             if tokens:

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -124,8 +124,12 @@ class RequestPhase:
         return Confirm.ask("    Approve?", default=True)
 
 
+MAX_HARDEN_REPAIRS = 2  # total repair sessions across the phase (bounds cost/time)
+MAX_REPAIR_ITERATIONS = 8  # tool-call turns per repair session
+
+
 class HardenPhase:
-    """Run acceptance checks and validation."""
+    """Run acceptance checks; optionally repair a failing check and re-run it."""
 
     async def run(
         self,
@@ -136,6 +140,8 @@ class HardenPhase:
         event_log: EventLog,
         deadline: Deadline,
         ui: ConsoleUI | None = None,
+        provider: LLMProvider | None = None,
+        tokens: TokenTracker | None = None,
     ) -> list[dict[str, Any]]:
         event_log.emit(
             phase=Phase.HARDEN.value,
@@ -157,6 +163,8 @@ class HardenPhase:
             if ap.cmd:
                 checks.append((ap.name, ap.cmd, ap.expect_output))
 
+        repairs_left = MAX_HARDEN_REPAIRS
+
         for name, cmd, expect in checks:
             if deadline.is_expired() or deadline.should_transition(Phase.HARDEN):
                 results.append({"name": name, "cmd": cmd, "passed": False, "skipped": True})
@@ -165,22 +173,26 @@ class HardenPhase:
             if ui:
                 ui.tool_activity("check", name, deadline)
 
-            result = await dispatcher.dispatch(
-                "exec_command", {"command": cmd, "timeout": 30}, context
-            )
-            exit_ok = result.status == "ok"
-            # A check passes only if the command succeeds AND, when an expected
-            # output is given, that text actually appears — so a check asserts
-            # behavior rather than just "the process started".
-            output_ok = expect is None or expect in result.display
-            passed = exit_ok and output_ok
+            passed, reason, output = await self._run_check(dispatcher, context, cmd, expect)
+            repaired = False
 
-            if not exit_ok:
-                reason = "command failed"
-            elif not output_ok:
-                reason = f"expected output not found: {expect!r}"
-            else:
-                reason = ""
+            # A failing check gets one bounded fix-and-retry when a provider is
+            # available and there's still repair budget and phase time.
+            if (
+                not passed
+                and provider is not None
+                and repairs_left > 0
+                and not deadline.is_expired()
+                and not deadline.should_transition(Phase.HARDEN)
+            ):
+                repairs_left -= 1
+                if ui:
+                    ui.tool_activity("repair", f"fixing: {name}", deadline)
+                await self._attempt_repair(
+                    name, cmd, expect, output, dispatcher, context, provider, deadline, tokens
+                )
+                passed, reason, output = await self._run_check(dispatcher, context, cmd, expect)
+                repaired = passed
 
             results.append(
                 {
@@ -189,16 +201,19 @@ class HardenPhase:
                     "expect": expect,
                     "passed": passed,
                     "reason": reason,
-                    "output": result.display[:1000],
+                    "repaired": repaired,
+                    "output": output[:1000],
                 }
             )
 
             event_log.emit(
                 phase=Phase.HARDEN.value,
                 event_type="acceptance.check",
-                summary=f"{'✓' if passed else '✗'} {name}" + (f" ({reason})" if reason else ""),
+                summary=f"{'✓' if passed else '✗'} {name}"
+                + (" (repaired)" if repaired else "")
+                + (f" ({reason})" if reason and not passed else ""),
                 data={"name": name, "cmd": cmd, "expect": expect},
-                result={"passed": passed, "reason": reason},
+                result={"passed": passed, "reason": reason, "repaired": repaired},
             )
 
         event_log.emit(
@@ -208,6 +223,84 @@ class HardenPhase:
         )
 
         return results
+
+    async def _run_check(
+        self,
+        dispatcher: ToolDispatcher,
+        context: ToolContext,
+        cmd: str,
+        expect: str | None,
+    ) -> tuple[bool, str, str]:
+        """Run one check; a pass needs exit 0 and (if given) the expected output."""
+        result = await dispatcher.dispatch("exec_command", {"command": cmd, "timeout": 30}, context)
+        exit_ok = result.status == "ok"
+        output_ok = expect is None or expect in result.display
+        if not exit_ok:
+            reason = "command failed"
+        elif not output_ok:
+            reason = f"expected output not found: {expect!r}"
+        else:
+            reason = ""
+        return exit_ok and output_ok, reason, result.display
+
+    async def _attempt_repair(
+        self,
+        name: str,
+        cmd: str,
+        expect: str | None,
+        output: str,
+        dispatcher: ToolDispatcher,
+        context: ToolContext,
+        provider: LLMProvider,
+        deadline: Deadline,
+        tokens: TokenTracker | None,
+    ) -> None:
+        """Run a small bounded agent to fix whatever made the check fail."""
+        expect_line = f"\nIt must also contain: {expect!r}" if expect else ""
+        system = f"""\
+An acceptance check for this project failed. Fix the underlying cause so the
+check passes. The project is in {context.workspace}.
+
+Failing check: {name}
+Command: {cmd}{expect_line}
+
+Command output:
+{output[:1500]}
+
+Inspect the relevant files (read_file, search_files) and fix the code or config
+(edit_file, write_file). Keep the change minimal and targeted at this failure —
+do not rewrite unrelated files. You do not need to re-run the check yourself;
+the harness re-runs it after you finish.
+"""
+        messages: list[Message] = [
+            Message(role="system", content=system),
+            Message(role="user", content=f"Fix the failing check: {name}."),
+        ]
+        tool_schemas = [
+            ToolSchema(name=s["name"], description=s["description"], parameters=s["parameters"])
+            for s in dispatcher.to_schemas()
+        ]
+
+        for _i in range(MAX_REPAIR_ITERATIONS):
+            if deadline.is_expired() or deadline.should_transition(Phase.HARDEN):
+                return
+            response = await provider.complete(messages, tools=tool_schemas, effort="medium")
+            if tokens:
+                tokens.add(response.usage)
+            messages.append(
+                Message(role="assistant", content=response.content, tool_calls=response.tool_calls)
+            )
+            if not response.tool_calls:
+                return
+            for tc in response.tool_calls:
+                result = await dispatcher.dispatch(tc.name, tc.arguments, context)
+                messages.append(
+                    Message(
+                        role="tool",
+                        content=result.display or json.dumps(result.data),
+                        tool_call_id=tc.id,
+                    )
+                )
 
 
 class VerifyPhase:

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -244,10 +244,14 @@ Work quickly — this is time-boxed and the user is waiting on a working demo.
 Approach:
 1. Find the dependency manifest (one list_directory of the root is enough).
 2. Install dependencies (`python3 -m pip install -r requirements.txt` or `npm install`).
-3. Start the app in the background and confirm it serves a request, e.g.
-   `nohup python3 app.py > /dev/null 2>&1 &` then `sleep 2 && curl -s localhost:5000`.
-   Node apps: `npm start &` (or `node server.js &`), then curl the port it logs.
-4. If it responds, you are done — a successful curl is sufficient evidence.
+3. Start the app in the background, e.g. `nohup python3 app.py > /dev/null 2>&1 &`,
+   or `npm start &` / `node server.js &` for Node apps.
+4. Prove it works by calling confirm_running with a command that demonstrates it —
+   usually a curl, e.g. `curl -sf localhost:5000`. Provide an expected substring
+   when you know one (e.g. a title from the page). The harness will actually run
+   your command and only accept the verification if it really succeeds, so pick a
+   command that genuinely exercises the app — asserting success without a passing
+   command will not work.
 
 Environment notes:
 - Use `python3` and `python3 -m pip`, not `python`/`pip`.
@@ -256,17 +260,18 @@ Environment notes:
   `lsof -ti :<PORT> | xargs kill`. If the app uses a non-default port, curl that port.
 - You don't need to read every file or understand all the code to verify it runs.
 
-If it can't be made to run in a few fix attempts, report the blocker rather than
-looping. End with exactly one verdict line:
-- `VERIFIED: <one-line description>` if the app runs
-- `FAILED: <what's broken>` if it can't be made to run
+If you cannot get it running after a few fix attempts, call report_failed with
+the blocker instead of looping.
 """
 
         messages: list[Message] = [
             Message(role="system", content=system),
             Message(
                 role="user",
-                content=f"Get {spec.name} running NOW. Install deps, start server, curl it. Go.",
+                content=(
+                    f"Get {spec.name} running. Install deps, start the server, then "
+                    "call confirm_running with a command that proves it responds."
+                ),
             ),
         ]
 
@@ -274,11 +279,16 @@ looping. End with exactly one verdict line:
             ToolSchema(name=s["name"], description=s["description"], parameters=s["parameters"])
             for s in dispatcher.to_schemas()
         ]
+        tool_schemas.extend(_verify_virtual_tools())
 
-        # Aggressive agent loop — more iterations than build phase gets
+        # Cap how many times the agent may propose a proof command that fails,
+        # so it can't loop forever on bad checks.
+        confirm_attempts = 0
+        max_confirm_attempts = 5
+
         for _i in range(MAX_VERIFY_ITERATIONS):
             if deadline.is_expired():
-                return False, "Deadline expired during verification"
+                return self._fail(event_log, "Deadline expired during verification")
 
             response = await provider.complete(messages, tools=tool_schemas)
             if tokens:
@@ -287,31 +297,8 @@ looping. End with exactly one verdict line:
             messages.append(
                 Message(role="assistant", content=response.content, tool_calls=response.tool_calls)
             )
-
-            if response.content:
-                if ui:
-                    ui.tool_activity("verify", response.content[:80], deadline)
-
-                # Check for final verdict
-                content_upper = response.content.upper()
-                if "VERIFIED:" in content_upper:
-                    idx = response.content.upper().index("VERIFIED:")
-                    msg = response.content[idx + 9 :].strip()
-                    event_log.emit(
-                        phase=Phase.VERIFY.value,
-                        event_type="verify.pass",
-                        summary=f"MVP verified: {msg}",
-                    )
-                    return True, msg
-                if "FAILED:" in content_upper:
-                    idx = response.content.upper().index("FAILED:")
-                    msg = response.content[idx + 7 :].strip()
-                    event_log.emit(
-                        phase=Phase.VERIFY.value,
-                        event_type="verify.fail",
-                        summary=f"MVP failed: {msg}",
-                    )
-                    return False, msg
+            if response.content and ui:
+                ui.tool_activity("verify", response.content[:80], deadline)
 
             if not response.tool_calls:
                 if response.stop_reason == "end_turn":
@@ -319,6 +306,23 @@ looping. End with exactly one verdict line:
                 continue
 
             for tc in response.tool_calls:
+                if tc.name == "report_failed":
+                    reason = str(tc.arguments.get("reason", "unspecified"))
+                    return self._fail(event_log, reason)
+
+                if tc.name == "confirm_running":
+                    ok, detail = await self._run_confirmation(tc, dispatcher, context, ui, deadline)
+                    if ok:
+                        return self._pass(event_log, detail)
+                    confirm_attempts += 1
+                    messages.append(Message(role="tool", content=detail, tool_call_id=tc.id))
+                    if confirm_attempts >= max_confirm_attempts:
+                        return self._fail(
+                            event_log,
+                            "Could not confirm the app runs after several attempts",
+                        )
+                    continue
+
                 if ui:
                     ui.tool_activity(tc.name, tool_summary(tc.name, tc.arguments), deadline)
                 result = await dispatcher.dispatch(tc.name, tc.arguments, context)
@@ -330,7 +334,103 @@ looping. End with exactly one verdict line:
                     )
                 )
 
-        return False, "Verification did not complete"
+        return self._fail(event_log, "Verification did not complete")
+
+    async def _run_confirmation(
+        self,
+        tc: Any,
+        dispatcher: ToolDispatcher,
+        context: ToolContext,
+        ui: ConsoleUI | None,
+        deadline: Deadline,
+    ) -> tuple[bool, str]:
+        """Independently run the agent's proof command and judge the result.
+
+        The verdict is based on what the command actually does, not on the
+        agent's assertion — this is the whole point of the phase.
+        """
+        command = str(tc.arguments.get("command", "")).strip()
+        expect = tc.arguments.get("expect")
+        summary = str(tc.arguments.get("summary", "")).strip()
+        if not command:
+            return False, "confirm_running needs a command that demonstrates the app works."
+
+        if ui:
+            ui.tool_activity("confirm", command[:80], deadline)
+        result = await dispatcher.dispatch(
+            "exec_command", {"command": command, "timeout": 15}, context
+        )
+        if result.status != "ok":
+            return False, f"That command failed:\n{result.display[:800]}\nKeep fixing and retry."
+        if expect and str(expect) not in result.display:
+            return False, (
+                f"The command ran but its output did not contain {str(expect)!r}:\n"
+                f"{result.display[:800]}\nFix the app or correct the check, then retry."
+            )
+
+        detail = summary or f"confirmed via `{command}`"
+        return True, detail
+
+    def _pass(self, event_log: EventLog, detail: str) -> tuple[bool, str]:
+        event_log.emit(
+            phase=Phase.VERIFY.value,
+            event_type="verify.pass",
+            summary=f"MVP verified (independently confirmed): {detail}",
+        )
+        return True, detail
+
+    def _fail(self, event_log: EventLog, reason: str) -> tuple[bool, str]:
+        event_log.emit(
+            phase=Phase.VERIFY.value,
+            event_type="verify.fail",
+            summary=f"MVP not verified: {reason}",
+        )
+        return False, reason
+
+
+def _verify_virtual_tools() -> list[ToolSchema]:
+    """Tools the verify agent uses to report a verdict; handled by the phase."""
+    return [
+        ToolSchema(
+            name="confirm_running",
+            description=(
+                "Assert the app is running by giving a command that proves it. The "
+                "harness runs the command itself and only accepts the verification "
+                "if it exits 0 (and, if 'expect' is given, its output contains that "
+                "text). Use this once the app responds."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Command that demonstrates the app works, e.g. "
+                        "'curl -sf localhost:5000'",
+                    },
+                    "expect": {
+                        "type": "string",
+                        "description": "Optional substring the command's output must contain",
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "One-line description of what runs",
+                    },
+                },
+                "required": ["command"],
+            },
+        ),
+        ToolSchema(
+            name="report_failed",
+            description="Report that the app cannot be made to run, with the blocker.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "reason": {"type": "string", "description": "What is broken"},
+                },
+                "required": ["reason"],
+            },
+        ),
+    ]
 
 
 class HandoffPhase:

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -146,18 +146,18 @@ class HardenPhase:
 
         results: list[dict[str, Any]] = []
 
-        # Collect all cmd: checks from spec and plan
-        checks: list[tuple[str, str]] = []
+        # Collect all cmd: checks from spec and plan as (name, cmd, expect).
+        checks: list[tuple[str, str, str | None]] = []
 
         for ac in spec.acceptance:
             if ac.is_cmd and ac.command:
-                checks.append((ac.raw, ac.command))
+                checks.append((ac.raw, ac.command, ac.expect))
 
         for ap in plan.acceptance_plan:
             if ap.cmd:
-                checks.append((ap.name, ap.cmd))
+                checks.append((ap.name, ap.cmd, ap.expect_output))
 
-        for name, cmd in checks:
+        for name, cmd, expect in checks:
             if deadline.is_expired() or deadline.should_transition(Phase.HARDEN):
                 results.append({"name": name, "cmd": cmd, "passed": False, "skipped": True})
                 continue
@@ -168,12 +168,27 @@ class HardenPhase:
             result = await dispatcher.dispatch(
                 "exec_command", {"command": cmd, "timeout": 30}, context
             )
-            passed = result.status == "ok"
+            exit_ok = result.status == "ok"
+            # A check passes only if the command succeeds AND, when an expected
+            # output is given, that text actually appears — so a check asserts
+            # behavior rather than just "the process started".
+            output_ok = expect is None or expect in result.display
+            passed = exit_ok and output_ok
+
+            if not exit_ok:
+                reason = "command failed"
+            elif not output_ok:
+                reason = f"expected output not found: {expect!r}"
+            else:
+                reason = ""
+
             results.append(
                 {
                     "name": name,
                     "cmd": cmd,
+                    "expect": expect,
                     "passed": passed,
+                    "reason": reason,
                     "output": result.display[:1000],
                 }
             )
@@ -181,9 +196,9 @@ class HardenPhase:
             event_log.emit(
                 phase=Phase.HARDEN.value,
                 event_type="acceptance.check",
-                summary=f"{'✓' if passed else '✗'} {name}",
-                data={"name": name, "cmd": cmd},
-                result={"passed": passed},
+                summary=f"{'✓' if passed else '✗'} {name}" + (f" ({reason})" if reason else ""),
+                data={"name": name, "cmd": cmd, "expect": expect},
+                result={"passed": passed, "reason": reason},
             )
 
         event_log.emit(

--- a/noscope/planning/models.py
+++ b/noscope/planning/models.py
@@ -27,6 +27,9 @@ class AcceptancePlan(BaseModel):
     name: str
     cmd: str | None = None
     must_pass: bool = True
+    # Optional substring the command's output must contain to pass (in addition
+    # to exiting 0). Lets a check assert real behavior, not just "it started".
+    expect_output: str | None = None
 
 
 class PlanOutput(BaseModel):

--- a/noscope/spec/models.py
+++ b/noscope/spec/models.py
@@ -8,18 +8,31 @@ from pydantic import BaseModel, field_validator
 
 
 class AcceptanceCheck(BaseModel):
-    """A single acceptance criterion from the spec."""
+    """A single acceptance criterion from the spec.
+
+    A ``cmd:`` check passes when the command exits 0. Append ``==> <text>`` to
+    also require that ``<text>`` appears in the command's output, e.g.::
+
+        cmd: curl -s localhost:5000 ==> Hello
+    """
 
     raw: str
     is_cmd: bool = False
     command: str | None = None
+    expect: str | None = None
 
     @classmethod
     def from_string(cls, s: str) -> AcceptanceCheck:
         s = s.strip()
         if s.lower().startswith("cmd:"):
-            cmd = s[4:].strip()
-            return cls(raw=s, is_cmd=True, command=cmd)
+            body = s[4:].strip()
+            command, _, expect = body.partition("==>")
+            return cls(
+                raw=s,
+                is_cmd=True,
+                command=command.strip(),
+                expect=expect.strip() or None,
+            )
         return cls(raw=s)
 
 

--- a/noscope/supervisor.py
+++ b/noscope/supervisor.py
@@ -373,6 +373,8 @@ RULES:
 - The project structure and dependencies are already set up — do NOT reinstall or reconfigure
 - Write code for YOUR tasks only
 - Do NOT modify files that other agents might be working on
+- To change an existing file, use edit_file (targeted string replacement), not write_file — it's cheaper and won't clobber unrelated content
+- Use write_file only to create a new file or fully replace one you own
 - Call mark_task_complete after finishing each task
 - If you need a file that doesn't exist yet, create it — another agent may not have written it yet
 - NEVER use interactive scaffolding tools (create-react-app, npm create, etc)

--- a/noscope/tools/base.py
+++ b/noscope/tools/base.py
@@ -63,6 +63,8 @@ def tool_summary(name: str, args: dict[str, Any]) -> str:
     """Create a brief human-readable summary of a tool call."""
     if name == "write_file":
         return f"writing {args.get('path', '?')}"
+    if name == "edit_file":
+        return f"editing {args.get('path', '?')}"
     if name == "read_file":
         return f"reading {args.get('path', '?')}"
     if name == "exec_command":

--- a/noscope/tools/base.py
+++ b/noscope/tools/base.py
@@ -72,6 +72,10 @@ def tool_summary(name: str, args: dict[str, Any]) -> str:
         return str(cmd[:80]) if len(cmd) <= 80 else str(cmd[:77]) + "..."
     if name == "list_directory":
         return f"listing {args.get('path', '.')}"
+    if name == "search_files":
+        return f"searching /{args.get('pattern', '')}/"
+    if name == "find_files":
+        return f"finding {args.get('pattern', '')}"
     if name == "create_directory":
         return f"creating {args.get('path', '?')}"
     if name in ("git_init", "git_status", "git_add", "git_commit", "git_diff"):

--- a/noscope/tools/docker.py
+++ b/noscope/tools/docker.py
@@ -8,6 +8,9 @@ container with zero risk to the host.
 from __future__ import annotations
 
 import asyncio
+import base64
+import posixpath
+import re
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +22,45 @@ from noscope.tools.safety import check_command_safety
 DOCKER_IMAGE = "python:3.12-slim"
 DOCKER_MEMORY_LIMIT = "1g"
 DOCKER_CPU_LIMIT = "2.0"
+
+# Container paths are interpolated into shell strings, so restrict them to a
+# safe allowlist: no shell metacharacters, no absolute paths, no traversal.
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def safe_container_path(rel_path: str) -> str:
+    """Validate a workspace-relative path for safe use in a container command.
+
+    Rejects absolute paths, ``..`` traversal, and anything outside a safe
+    character set — closing the path-injection hole where a crafted path could
+    escape /workspace or inject a shell command. Returns the normalized path.
+    """
+    rel = (rel_path or "").strip()
+    if rel in ("", ".", "./"):
+        return "."
+    if rel.startswith("/"):
+        raise ValueError(f"Absolute paths are not allowed: {rel_path!r}")
+    if rel.startswith("./"):  # strip a single leading "./", nothing more
+        rel = rel[2:]
+    if not _SAFE_PATH_RE.match(rel):
+        raise ValueError(f"Unsafe characters in path: {rel_path!r}")
+    if ".." in rel.split("/"):
+        raise ValueError(f"Path traversal is not allowed: {rel_path!r}")
+    return rel
+
+
+def build_write_command(rel_path: str, content: str) -> str:
+    """Build a shell command that writes content to a container path safely.
+
+    Uses base64 so arbitrary file content — backslashes, quotes, the heredoc
+    marker, anything — round-trips exactly, instead of the old heredoc that
+    doubled backslashes and could be truncated by the content itself.
+    """
+    path = safe_container_path(rel_path)
+    b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    parent = posixpath.dirname(path)
+    mkdir = f"mkdir -p '/workspace/{parent}' && " if parent else ""
+    return f"{mkdir}printf %s '{b64}' | base64 -d > '/workspace/{path}'"
 
 
 class DockerSandbox:
@@ -177,33 +219,34 @@ class DockerFileTool:
 
     async def _read_in_container(self, rel_path: str) -> tuple[bool, str]:
         """Read a file inside the container. Returns (success, content_or_error)."""
-        code, stdout, stderr = await self._sandbox.execute(
-            f'cat "/workspace/{rel_path}"', timeout=10
-        )
+        try:
+            path = safe_container_path(rel_path)
+        except ValueError as e:
+            return False, str(e)
+        code, stdout, stderr = await self._sandbox.execute(f"cat '/workspace/{path}'", timeout=10)
         if code != 0:
             return False, stderr or f"File not found: {rel_path}"
         return True, stdout
 
     async def _write_in_container(self, rel_path: str, content: str) -> tuple[bool, str]:
         """Write a file inside the container. Returns (success, error_msg)."""
-        # Ensure parent directory exists
-        parent = "/workspace/" + "/".join(rel_path.split("/")[:-1])
-        if parent != "/workspace/":
-            await self._sandbox.execute(f'mkdir -p "{parent}"', timeout=5)
-        # Write via heredoc to handle special characters
-        escaped = content.replace("\\", "\\\\").replace("'", "'\\''")
-        code, _, stderr = await self._sandbox.execute(
-            f"cat > '/workspace/{rel_path}' << 'NOSCOPE_EOF'\n{escaped}\nNOSCOPE_EOF",
-            timeout=30,
-        )
+        try:
+            command = build_write_command(rel_path, content)
+        except ValueError as e:
+            return False, str(e)
+        code, _, stderr = await self._sandbox.execute(command, timeout=30)
         if code != 0:
             return False, stderr
         return True, ""
 
     async def _list_in_container(self, rel_path: str) -> tuple[bool, str]:
         """List a directory inside the container. Returns (success, listing_or_error)."""
+        try:
+            path = safe_container_path(rel_path)
+        except ValueError as e:
+            return False, str(e)
         code, stdout, stderr = await self._sandbox.execute(
-            f'ls -1F "/workspace/{rel_path}"', timeout=10
+            f"ls -1F '/workspace/{path}'", timeout=10
         )
         if code != 0:
             return False, stderr or f"Directory not found: {rel_path}"
@@ -211,9 +254,11 @@ class DockerFileTool:
 
     async def _mkdir_in_container(self, rel_path: str) -> tuple[bool, str]:
         """Create a directory inside the container."""
-        code, _, stderr = await self._sandbox.execute(
-            f'mkdir -p "/workspace/{rel_path}"', timeout=5
-        )
+        try:
+            path = safe_container_path(rel_path)
+        except ValueError as e:
+            return False, str(e)
+        code, _, stderr = await self._sandbox.execute(f"mkdir -p '/workspace/{path}'", timeout=5)
         if code != 0:
             return False, stderr
         return True, ""

--- a/noscope/tools/filesystem.py
+++ b/noscope/tools/filesystem.py
@@ -1,7 +1,8 @@
-"""Filesystem tools — read, write, list, mkdir within workspace."""
+"""Filesystem tools — read, write, edit, list, mkdir within workspace."""
 
 from __future__ import annotations
 
+import difflib
 from typing import Any
 
 from noscope.capabilities import Capability
@@ -58,6 +59,99 @@ class WriteFileTool(Tool):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(args["content"], encoding="utf-8")
         return ToolResult.ok(display=f"Wrote {path}", path=str(path))
+
+
+class EditFileTool(Tool):
+    name = "edit_file"
+    description = (
+        "Edit an existing file by replacing an exact string. Prefer this over "
+        "write_file for changes to existing files — it only touches the target "
+        "region and returns a diff. old_string must match exactly (including "
+        "whitespace and indentation) and must be unique in the file unless "
+        "replace_all is true."
+    )
+    required_capability = Capability.WORKSPACE_RW
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path relative to workspace"},
+                "old_string": {
+                    "type": "string",
+                    "description": "Exact text to replace (include enough context to be unique)",
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "Replacement text",
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": "Replace every occurrence instead of requiring a unique match",
+                    "default": False,
+                },
+            },
+            "required": ["path", "old_string", "new_string"],
+        }
+
+    async def execute(self, args: dict[str, Any], context: ToolContext) -> ToolResult:
+        path = resolve_workspace_path(args["path"], context.workspace)
+        if not path.exists():
+            return ToolResult.error(f"File not found: {args['path']}")
+        if not path.is_file():
+            return ToolResult.error(f"Not a file: {args['path']}")
+
+        old_string = args["old_string"]
+        new_string = args["new_string"]
+        replace_all = bool(args.get("replace_all", False))
+
+        if old_string == new_string:
+            return ToolResult.error("old_string and new_string are identical — nothing to do")
+
+        try:
+            original = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return ToolResult.error(f"Cannot edit binary file: {args['path']}")
+
+        count = original.count(old_string)
+        if count == 0:
+            return ToolResult.error(
+                f"old_string not found in {args['path']} — it must match exactly, "
+                "including whitespace and indentation"
+            )
+        if count > 1 and not replace_all:
+            return ToolResult.error(
+                f"old_string appears {count} times in {args['path']}; add surrounding "
+                "context to make it unique, or set replace_all to replace every occurrence"
+            )
+
+        updated = original.replace(old_string, new_string)
+        path.write_text(updated, encoding="utf-8")
+
+        diff = _unified_diff(original, updated, args["path"])
+        replaced = count if replace_all else 1
+        return ToolResult.ok(
+            display=f"Edited {args['path']} ({replaced} replacement(s))\n{diff}",
+            path=str(path),
+            replacements=replaced,
+        )
+
+
+def _unified_diff(before: str, after: str, path: str) -> str:
+    """A compact unified diff, capped so large edits don't flood the context."""
+    lines = list(
+        difflib.unified_diff(
+            before.splitlines(),
+            after.splitlines(),
+            fromfile=path,
+            tofile=path,
+            lineterm="",
+            n=2,
+        )
+    )
+    if len(lines) > 60:
+        lines = lines[:60] + ["... (diff truncated)"]
+    return "\n".join(lines)
 
 
 class ListDirectoryTool(Tool):

--- a/noscope/tools/filesystem.py
+++ b/noscope/tools/filesystem.py
@@ -12,7 +12,11 @@ from noscope.tools.safety import resolve_workspace_path
 
 class ReadFileTool(Tool):
     name = "read_file"
-    description = "Read the contents of a file within the workspace"
+    description = (
+        "Read the contents of a file within the workspace. For large files, "
+        "pass offset (1-based start line) and limit (line count) to read only "
+        "a window instead of the whole file."
+    )
     required_capability = Capability.WORKSPACE_RW
 
     def parameters_schema(self) -> dict[str, Any]:
@@ -20,6 +24,14 @@ class ReadFileTool(Tool):
             "type": "object",
             "properties": {
                 "path": {"type": "string", "description": "File path relative to workspace"},
+                "offset": {
+                    "type": "integer",
+                    "description": "1-based line to start reading from (default: start of file)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of lines to read (default: all)",
+                },
             },
             "required": ["path"],
         }
@@ -35,6 +47,21 @@ class ReadFileTool(Tool):
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             return ToolResult.error(f"Cannot read binary file: {args['path']}")
+
+        offset = args.get("offset")
+        limit = args.get("limit")
+        if offset is not None or limit is not None:
+            lines = content.splitlines()
+            start = max(0, (int(offset) - 1)) if offset is not None else 0
+            end = start + int(limit) if limit is not None else len(lines)
+            window = lines[start:end]
+            display = "\n".join(window)
+            return ToolResult.ok(
+                display=display,
+                content=display,
+                path=str(path),
+                lines=f"{start + 1}-{start + len(window)} of {len(lines)}",
+            )
 
         return ToolResult.ok(display=content, content=content, path=str(path))
 

--- a/noscope/tools/search.py
+++ b/noscope/tools/search.py
@@ -1,0 +1,164 @@
+"""Search and discovery tools — grep and glob within the workspace."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from noscope.capabilities import Capability
+from noscope.tools.base import Tool, ToolContext, ToolResult
+from noscope.tools.safety import resolve_workspace_path
+
+# Directories never worth searching — build output, vendored deps, VCS, caches.
+_IGNORED_DIRS = {
+    ".git",
+    ".noscope",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".next",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+_MAX_FILE_BYTES = 1_000_000  # skip files larger than ~1 MB
+
+
+def _is_ignored(path: Path, workspace: Path) -> bool:
+    return any(part in _IGNORED_DIRS for part in path.relative_to(workspace).parts)
+
+
+def _looks_binary(data: bytes) -> bool:
+    return b"\x00" in data[:1024]
+
+
+class SearchFilesTool(Tool):
+    name = "search_files"
+    description = (
+        "Search file contents across the workspace with a regular expression. "
+        "Returns matching lines as 'path:line: text' so you can locate code "
+        "without reading whole files. Optionally restrict by a subdirectory or "
+        "a filename glob (e.g. '*.py')."
+    )
+    required_capability = Capability.WORKSPACE_RW
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string", "description": "Regular expression to search for"},
+                "path": {
+                    "type": "string",
+                    "description": "Subdirectory to search under (default: whole workspace)",
+                    "default": ".",
+                },
+                "glob": {
+                    "type": "string",
+                    "description": "Only search files whose name matches this glob, e.g. '*.py'",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum matching lines to return (default 100)",
+                    "default": 100,
+                },
+            },
+            "required": ["pattern"],
+        }
+
+    async def execute(self, args: dict[str, Any], context: ToolContext) -> ToolResult:
+        try:
+            regex = re.compile(args["pattern"])
+        except re.error as e:
+            return ToolResult.error(f"Invalid regular expression: {e}")
+
+        base = resolve_workspace_path(args.get("path", "."), context.workspace)
+        if not base.exists():
+            return ToolResult.error(f"Path not found: {args.get('path', '.')}")
+
+        workspace = context.workspace.resolve()
+        name_glob = args.get("glob")
+        max_results = int(args.get("max_results", 100))
+
+        matches: list[str] = []
+        truncated = False
+        for file in sorted(base.rglob("*")):
+            if not file.is_file() or _is_ignored(file, workspace):
+                continue
+            if name_glob and not file.match(name_glob):
+                continue
+            try:
+                if file.stat().st_size > _MAX_FILE_BYTES:
+                    continue
+                raw = file.read_bytes()
+            except OSError:
+                continue
+            if _looks_binary(raw):
+                continue
+
+            rel = file.relative_to(workspace)
+            for lineno, line in enumerate(raw.decode("utf-8", errors="replace").splitlines(), 1):
+                if regex.search(line):
+                    matches.append(f"{rel}:{lineno}: {line.strip()[:200]}")
+                    if len(matches) >= max_results:
+                        truncated = True
+                        break
+            if truncated:
+                break
+
+        if not matches:
+            return ToolResult.ok(display="(no matches)", count=0)
+        display = "\n".join(matches)
+        if truncated:
+            display += f"\n... (stopped at {max_results} matches)"
+        return ToolResult.ok(display=display, count=len(matches), truncated=truncated)
+
+
+class FindFilesTool(Tool):
+    name = "find_files"
+    description = (
+        "Find files in the workspace by glob pattern (e.g. '**/*.py', "
+        "'src/**/*.ts'). Returns matching paths — use it to discover the "
+        "project layout instead of listing directories one at a time."
+    )
+    required_capability = Capability.WORKSPACE_RW
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern relative to the workspace, e.g. '**/*.py'",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum paths to return (default 200)",
+                    "default": 200,
+                },
+            },
+            "required": ["pattern"],
+        }
+
+    async def execute(self, args: dict[str, Any], context: ToolContext) -> ToolResult:
+        workspace = context.workspace.resolve()
+        max_results = int(args.get("max_results", 200))
+
+        paths: list[str] = []
+        truncated = False
+        for match in sorted(workspace.glob(args["pattern"])):
+            if not match.is_file() or _is_ignored(match, workspace):
+                continue
+            paths.append(str(match.relative_to(workspace)))
+            if len(paths) >= max_results:
+                truncated = True
+                break
+
+        if not paths:
+            return ToolResult.ok(display="(no files matched)", count=0)
+        display = "\n".join(paths)
+        if truncated:
+            display += f"\n... (stopped at {max_results} files)"
+        return ToolResult.ok(display=display, count=len(paths), truncated=truncated)

--- a/noscope/ui/console.py
+++ b/noscope/ui/console.py
@@ -217,6 +217,7 @@ class ConsoleUI:
         model: str,
         cache_creation_tokens: int = 0,
         cache_read_tokens: int = 0,
+        token_budget: int | None = None,
     ) -> None:
         """Show comprehensive final summary — always displayed."""
         # Status line
@@ -267,6 +268,11 @@ class ConsoleUI:
                 f"  Cost:        unknown pricing for {model} "
                 f"({total_in:,} in / {output_tokens:,} out)"
             )
+
+        if token_budget is not None:
+            used = total_in + output_tokens
+            pct = f" ({used / token_budget:.0%})" if token_budget else ""
+            lines.append(f"  Budget:      {used:,} / {token_budget:,} tokens{pct}")
 
         self.console.print(
             Panel(

--- a/noscope/ui/console.py
+++ b/noscope/ui/console.py
@@ -26,13 +26,48 @@ MODEL_PRICING: dict[str, tuple[float, float]] = {
 }
 
 
+# Prompt-cache multipliers relative to the base input rate: reads are ~0.1x,
+# writes ~1.25x (5-minute TTL).
+_CACHE_READ_MULT = 0.1
+_CACHE_WRITE_MULT = 1.25
+
+
 def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float | None:
     """Estimated run cost in USD, or None when the model's pricing is unknown."""
+    return estimate_cost_detailed(model, input_tokens, output_tokens)[0]
+
+
+def estimate_cost_detailed(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
+) -> tuple[float | None, float]:
+    """Return (cost, cache_savings) in USD, or (None, 0.0) for unknown models.
+
+    ``cache_savings`` is what the cached prompt tokens would have cost at the
+    full input rate minus what they actually cost — the demonstrable payoff of
+    prompt caching.
+    """
     prices = MODEL_PRICING.get(model)
     if prices is None:
-        return None
+        return None, 0.0
     input_price, output_price = prices
-    return (input_tokens / 1_000_000 * input_price) + (output_tokens / 1_000_000 * output_price)
+    per = input_price / 1_000_000
+
+    cost = (
+        input_tokens * per
+        + cache_creation_tokens * per * _CACHE_WRITE_MULT
+        + cache_read_tokens * per * _CACHE_READ_MULT
+        + output_tokens / 1_000_000 * output_price
+    )
+    # What the cached tokens would have cost uncached, minus what they did cost.
+    full = (cache_creation_tokens + cache_read_tokens) * per
+    actual = (
+        cache_creation_tokens * per * _CACHE_WRITE_MULT + cache_read_tokens * per * _CACHE_READ_MULT
+    )
+    return cost, max(0.0, full - actual)
 
 
 class ConsoleUI:
@@ -180,6 +215,8 @@ class ConsoleUI:
         output_tokens: int,
         provider: str,
         model: str,
+        cache_creation_tokens: int = 0,
+        cache_read_tokens: int = 0,
     ) -> None:
         """Show comprehensive final summary — always displayed."""
         # Status line
@@ -214,15 +251,21 @@ class ConsoleUI:
         lines.append(f"  Event log:   [cyan]{run_dir / 'events.jsonl'}[/cyan]")
 
         # Cost
-        cost = estimate_cost(model, input_tokens, output_tokens)
+        cost, savings = estimate_cost_detailed(
+            model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens
+        )
+        total_in = input_tokens + cache_creation_tokens + cache_read_tokens
         if cost is not None:
-            lines.append(
-                f"  Cost:        ${cost:.4f} ({input_tokens:,} in / {output_tokens:,} out)"
-            )
+            cost_line = f"  Cost:        ${cost:.4f} ({total_in:,} in / {output_tokens:,} out)"
+            if cache_read_tokens or cache_creation_tokens:
+                cost_line += f"\n  Cache:       {cache_read_tokens:,} read" + (
+                    f", saved ${savings:.4f}" if savings else ""
+                )
+            lines.append(cost_line)
         else:
             lines.append(
                 f"  Cost:        unknown pricing for {model} "
-                f"({input_tokens:,} in / {output_tokens:,} out)"
+                f"({total_in:,} in / {output_tokens:,} out)"
             )
 
         self.console.print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noscope"
-version = "0.1.0"
+version = "0.2.0"
 description = "Time-boxed autonomous agent orchestration tool that builds runnable software MVPs from written specs"
 readme = "README.md"
 license = "MIT"
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "typer[all]",
+    "typer>=0.12",
     "rich",
     "pydantic>=2.0",
     "pydantic-settings",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -274,3 +274,71 @@ class TestAuditAgent:
         findings = await audit._run_checks()
         # Empty workspace = missing files finding
         assert any(f["type"] == "missing_files" for f in findings)
+
+
+class TestTokenBudget:
+    def test_exceeded_only_with_budget(self) -> None:
+        from noscope.phases import TokenTracker
+
+        unbounded = TokenTracker()
+        unbounded.add(Usage(input_tokens=1_000_000, output_tokens=1_000_000))
+        assert unbounded.exceeded() is False  # no budget -> never exceeded
+
+        capped = TokenTracker(budget=100)
+        capped.add(Usage(input_tokens=60, output_tokens=30))
+        assert capped.total() == 90
+        assert capped.exceeded() is False
+        capped.add(Usage(input_tokens=20))
+        assert capped.exceeded() is True
+
+    def test_total_counts_cache_tokens(self) -> None:
+        from noscope.phases import TokenTracker
+
+        t = TokenTracker()
+        t.add(
+            Usage(
+                input_tokens=1,
+                output_tokens=2,
+                cache_creation_input_tokens=3,
+                cache_read_input_tokens=4,
+            )
+        )
+        assert t.total() == 10
+
+    @pytest.mark.asyncio
+    async def test_build_agent_stops_on_budget(self, tool_context: ToolContext) -> None:
+        from noscope.logging.events import EventLog, RunDir
+        from noscope.phases import TokenTracker
+        from noscope.tools.dispatcher import ToolDispatcher
+
+        # Each call reports usage that exceeds the tiny budget; the agent should
+        # make at most one model call and then stop rather than looping.
+        calls = {"n": 0}
+
+        class CountingProvider(FakeProvider):
+            async def complete(
+                self,
+                messages: list[Message],
+                tools: list[ToolSchema] | None = None,
+                model: str | None = None,
+                json_schema: Any | None = None,
+                effort: str | None = None,
+            ) -> LLMResponse:
+                calls["n"] += 1
+                return LLMResponse(content="working", usage=Usage(input_tokens=1000))
+
+        run_dir = RunDir(base=tool_context.workspace.parent / "runs")
+        event_log = EventLog(run_dir)
+        tokens = TokenTracker(budget=100)
+        agent = BuildAgent(
+            agent_id="w",
+            provider=CountingProvider([]),
+            dispatcher=ToolDispatcher(),
+            context=tool_context,
+            event_log=event_log,
+            deadline=tool_context.deadline,
+            tokens=tokens,
+        )
+        await agent.run([PlanTask(id="t1", title="Build", kind="edit")], "Build it.")
+        event_log.close()
+        assert calls["n"] == 1  # stopped after the first over-budget call

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -7,13 +7,100 @@ from pathlib import Path
 import pytest
 
 from noscope.deadline import Deadline
+from noscope.llm.base import LLMResponse, Message, ToolCall, ToolSchema, Usage
 from noscope.logging.events import EventLog, RunDir
-from noscope.phases import HandoffPhase, HardenPhase, RequestPhase
+from noscope.phases import HandoffPhase, HardenPhase, RequestPhase, VerifyPhase
 from noscope.planning.models import AcceptancePlan, PlanOutput, PlanTask
 from noscope.spec.models import SpecInput
 from noscope.tools.base import ToolContext
 from noscope.tools.dispatcher import ToolDispatcher
 from noscope.tools.shell import ShellTool
+
+
+class _ToolProvider:
+    """Fake provider that replays canned tool-call responses."""
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = responses
+        self._idx = 0
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        model: str | None = None,
+        json_schema: object | None = None,
+        effort: str | None = None,
+    ) -> LLMResponse:
+        if self._idx < len(self._responses):
+            resp = self._responses[self._idx]
+            self._idx += 1
+            return resp
+        return LLMResponse(content="done", stop_reason="end_turn", usage=Usage())
+
+
+def _confirm(command: str, expect: str | None = None) -> LLMResponse:
+    args: dict[str, object] = {"command": command}
+    if expect is not None:
+        args["expect"] = expect
+    return LLMResponse(
+        tool_calls=[ToolCall(id="c1", name="confirm_running", arguments=args)],
+        usage=Usage(),
+    )
+
+
+def _report_failed(reason: str) -> LLMResponse:
+    return LLMResponse(
+        tool_calls=[ToolCall(id="f1", name="report_failed", arguments={"reason": reason})],
+        usage=Usage(),
+    )
+
+
+@pytest.mark.asyncio
+class TestVerifyPhase:
+    """VERIFY confirms by running the agent's proof command, not by trusting it."""
+
+    def _dispatcher(self) -> ToolDispatcher:
+        d = ToolDispatcher()
+        d.register(ShellTool())
+        return d
+
+    async def test_confirmation_must_actually_pass(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        # Agent proposes a command that really succeeds -> verified.
+        provider = _ToolProvider([_confirm("echo READY", expect="READY")])
+        spec = SpecInput(name="App", timebox="5m")
+        ok, msg = await VerifyPhase().run(
+            spec, provider, self._dispatcher(), tool_context, event_log, tool_context.deadline
+        )
+        assert ok is True
+
+    async def test_failing_proof_is_rejected(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        # First proof command fails; the agent then gives up. The harness must
+        # not accept the failing proof as success.
+        provider = _ToolProvider([_confirm("false"), _report_failed("cannot start")])
+        spec = SpecInput(name="App", timebox="5m")
+        ok, msg = await VerifyPhase().run(
+            spec, provider, self._dispatcher(), tool_context, event_log, tool_context.deadline
+        )
+        assert ok is False
+        assert "cannot start" in msg
+
+    async def test_wrong_output_is_rejected(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        # Command exits 0 but its output lacks the expected text -> not verified.
+        provider = _ToolProvider(
+            [_confirm("echo nope", expect="READY"), _report_failed("wrong content")]
+        )
+        spec = SpecInput(name="App", timebox="5m")
+        ok, _ = await VerifyPhase().run(
+            spec, provider, self._dispatcher(), tool_context, event_log, tool_context.deadline
+        )
+        assert ok is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -8,9 +8,58 @@ import pytest
 
 from noscope.deadline import Deadline
 from noscope.logging.events import EventLog, RunDir
-from noscope.phases import HandoffPhase, RequestPhase
-from noscope.planning.models import PlanOutput, PlanTask
+from noscope.phases import HandoffPhase, HardenPhase, RequestPhase
+from noscope.planning.models import AcceptancePlan, PlanOutput, PlanTask
 from noscope.spec.models import SpecInput
+from noscope.tools.base import ToolContext
+from noscope.tools.dispatcher import ToolDispatcher
+from noscope.tools.shell import ShellTool
+
+
+@pytest.mark.asyncio
+class TestHardenPhase:
+    """HARDEN runs real shell commands — no LLM, so these assert real behavior."""
+
+    def _dispatcher(self) -> ToolDispatcher:
+        d = ToolDispatcher()
+        d.register(ShellTool())
+        return d
+
+    async def test_exit_code_pass_and_fail(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        plan = PlanOutput(
+            acceptance_plan=[
+                AcceptancePlan(name="ok", cmd="true"),
+                AcceptancePlan(name="bad", cmd="false"),
+            ]
+        )
+        spec = SpecInput(name="T", timebox="5m")
+        results = await HardenPhase().run(
+            plan, spec, self._dispatcher(), tool_context, event_log, tool_context.deadline
+        )
+        by_name = {r["name"]: r for r in results}
+        assert by_name["ok"]["passed"] is True
+        assert by_name["bad"]["passed"] is False
+
+    async def test_expected_output_enforced(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        plan = PlanOutput(
+            acceptance_plan=[
+                AcceptancePlan(name="match", cmd="echo hello world", expect_output="hello"),
+                AcceptancePlan(name="nomatch", cmd="echo goodbye", expect_output="hello"),
+            ]
+        )
+        spec = SpecInput(name="T", timebox="5m")
+        results = await HardenPhase().run(
+            plan, spec, self._dispatcher(), tool_context, event_log, tool_context.deadline
+        )
+        by_name = {r["name"]: r for r in results}
+        # Command exits 0 both times; only the one whose output matches passes.
+        assert by_name["match"]["passed"] is True
+        assert by_name["nomatch"]["passed"] is False
+        assert "expected output not found" in by_name["nomatch"]["reason"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -148,6 +148,57 @@ class TestHardenPhase:
         assert by_name["nomatch"]["passed"] is False
         assert "expected output not found" in by_name["nomatch"]["reason"]
 
+    async def test_repair_makes_a_failing_check_pass(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        # The check greps for a file that doesn't exist yet, so it fails first.
+        # The repair "agent" writes that file; the re-run then passes.
+        from noscope.tools.filesystem import WriteFileTool
+
+        dispatcher = self._dispatcher()
+        dispatcher.register(WriteFileTool())
+
+        fix = LLMResponse(
+            tool_calls=[
+                ToolCall(
+                    id="w1",
+                    name="write_file",
+                    arguments={"path": "marker.txt", "content": "READY\n"},
+                )
+            ],
+            usage=Usage(),
+        )
+        provider = _ToolProvider([fix])
+
+        plan = PlanOutput(
+            acceptance_plan=[
+                AcceptancePlan(name="marker", cmd="cat marker.txt", expect_output="READY")
+            ]
+        )
+        spec = SpecInput(name="T", timebox="5m")
+        results = await HardenPhase().run(
+            plan,
+            spec,
+            dispatcher,
+            tool_context,
+            event_log,
+            tool_context.deadline,
+            provider=provider,
+        )
+        assert results[0]["passed"] is True
+        assert results[0]["repaired"] is True
+
+    async def test_no_repair_without_provider(
+        self, tool_context: ToolContext, event_log: EventLog
+    ) -> None:
+        plan = PlanOutput(acceptance_plan=[AcceptancePlan(name="x", cmd="false")])
+        spec = SpecInput(name="T", timebox="5m")
+        results = await HardenPhase().run(
+            plan, spec, self._dispatcher(), tool_context, event_log, tool_context.deadline
+        )
+        assert results[0]["passed"] is False
+        assert results[0]["repaired"] is False
+
 
 @pytest.mark.asyncio
 class TestRequestPhase:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -80,3 +80,23 @@ class TestCostEstimation:
         from noscope.ui.console import estimate_cost
 
         assert estimate_cost("some-future-model", 1000, 1000) is None
+
+
+class TestCacheAwareCost:
+    def test_cache_read_is_cheaper_and_reports_savings(self) -> None:
+        from noscope.ui.console import estimate_cost_detailed
+
+        # 1M uncached vs 1M cache-read on claude-sonnet-5 ($3/MTok input)
+        uncached, _ = estimate_cost_detailed("claude-sonnet-5", 1_000_000, 0)
+        cached, savings = estimate_cost_detailed("claude-sonnet-5", 0, 0, 0, 1_000_000)
+        assert cached is not None and uncached is not None
+        assert cached < uncached  # reads bill at ~0.1x
+        # savings ≈ full input price ($3) minus the 0.1x actually paid ($0.30)
+        assert abs(savings - 2.70) < 0.01
+
+    def test_unknown_model_none(self) -> None:
+        from noscope.ui.console import estimate_cost_detailed
+
+        cost, savings = estimate_cost_detailed("mystery", 100, 100, 0, 100)
+        assert cost is None
+        assert savings == 0.0

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -51,6 +51,16 @@ class TestAcceptanceCheck:
         assert ac.is_cmd is True
         assert ac.command == "echo hello"
 
+    def test_expected_output(self) -> None:
+        ac = AcceptanceCheck.from_string("cmd: curl -s localhost:5000 ==> Hello")
+        assert ac.is_cmd is True
+        assert ac.command == "curl -s localhost:5000"
+        assert ac.expect == "Hello"
+
+    def test_no_expected_output(self) -> None:
+        ac = AcceptanceCheck.from_string("cmd: pytest -q")
+        assert ac.expect is None
+
 
 class TestParseSpec:
     def test_valid_spec(self, sample_spec_path: Path) -> None:

--- a/tests/test_tools/test_docker.py
+++ b/tests/test_tools/test_docker.py
@@ -1,0 +1,61 @@
+"""Tests for Docker sandbox path safety and file writes (pure helpers)."""
+
+from __future__ import annotations
+
+import base64
+import re
+
+import pytest
+
+from noscope.tools.docker import build_write_command, safe_container_path
+
+
+class TestSafeContainerPath:
+    def test_accepts_normal_paths(self) -> None:
+        assert safe_container_path("app.py") == "app.py"
+        assert safe_container_path("src/main.py") == "src/main.py"
+        assert safe_container_path("./config.json") == "config.json"
+        assert safe_container_path(".") == "."
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "/etc/passwd",
+            "../secret",
+            "a/../../b",
+            "a; rm -rf /",
+            "a$(whoami)",
+            "a`id`",
+            'a" b',
+            "a' b",
+            "a | b",
+        ],
+    )
+    def test_rejects_unsafe_paths(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            safe_container_path(bad)
+
+
+class TestBuildWriteCommand:
+    def _decode(self, cmd: str) -> str:
+        m = re.search(r"printf %s '([^']+)'", cmd)
+        assert m is not None
+        return base64.b64decode(m.group(1)).decode("utf-8")
+
+    def test_round_trips_tricky_content(self) -> None:
+        # Backslashes, quotes, the old heredoc marker, and newlines all survive
+        # exactly — the failure modes of the previous heredoc implementation.
+        content = "x = 1\n\\n not a newline\n'single'\n\"double\"\nNOSCOPE_EOF\n"
+        cmd = build_write_command("src/app.py", content)
+        assert self._decode(cmd) == content
+        assert "/workspace/src/app.py" in cmd
+        assert "mkdir -p '/workspace/src'" in cmd
+
+    def test_no_mkdir_for_root_file(self) -> None:
+        cmd = build_write_command("app.py", "print(1)\n")
+        assert "mkdir" not in cmd
+        assert self._decode(cmd) == "print(1)\n"
+
+    def test_rejects_unsafe_path(self) -> None:
+        with pytest.raises(ValueError):
+            build_write_command("../escape.py", "data")

--- a/tests/test_tools/test_filesystem.py
+++ b/tests/test_tools/test_filesystem.py
@@ -139,3 +139,20 @@ class TestCreateDirectoryTool:
         result = await tool.execute({"path": "a/b/c"}, tool_context)
         assert result.status == "ok"
         assert (tool_context.workspace / "a/b/c").is_dir()
+
+
+@pytest.mark.asyncio
+class TestReadFilePartial:
+    async def test_offset_and_limit(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "f.txt").write_text("l1\nl2\nl3\nl4\nl5\n")
+        tool = ReadFileTool()
+        result = await tool.execute({"path": "f.txt", "offset": 2, "limit": 2}, tool_context)
+        assert result.status == "ok"
+        assert result.data["content"] == "l2\nl3"
+        assert result.data["lines"] == "2-3 of 5"
+
+    async def test_full_read_unchanged(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "f.txt").write_text("a\nb\n")
+        tool = ReadFileTool()
+        result = await tool.execute({"path": "f.txt"}, tool_context)
+        assert result.data["content"] == "a\nb\n"

--- a/tests/test_tools/test_filesystem.py
+++ b/tests/test_tools/test_filesystem.py
@@ -7,10 +7,71 @@ import pytest
 from noscope.tools.base import ToolContext
 from noscope.tools.filesystem import (
     CreateDirectoryTool,
+    EditFileTool,
     ListDirectoryTool,
     ReadFileTool,
     WriteFileTool,
 )
+
+
+@pytest.mark.asyncio
+class TestEditFileTool:
+    async def test_unique_replacement(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "app.py").write_text("x = 1\ny = 2\n")
+        tool = EditFileTool()
+        result = await tool.execute(
+            {"path": "app.py", "old_string": "x = 1", "new_string": "x = 42"}, tool_context
+        )
+        assert result.status == "ok"
+        assert result.data["replacements"] == 1
+        assert (tool_context.workspace / "app.py").read_text() == "x = 42\ny = 2\n"
+
+    async def test_missing_old_string(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "app.py").write_text("hello\n")
+        tool = EditFileTool()
+        result = await tool.execute(
+            {"path": "app.py", "old_string": "nope", "new_string": "x"}, tool_context
+        )
+        assert result.status == "error"
+        assert "not found" in result.display
+
+    async def test_ambiguous_match_rejected(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "app.py").write_text("a\na\n")
+        tool = EditFileTool()
+        result = await tool.execute(
+            {"path": "app.py", "old_string": "a", "new_string": "b"}, tool_context
+        )
+        assert result.status == "error"
+        assert "appears 2 times" in result.display
+        # File is left untouched on an ambiguous match
+        assert (tool_context.workspace / "app.py").read_text() == "a\na\n"
+
+    async def test_replace_all(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "app.py").write_text("a\na\na\n")
+        tool = EditFileTool()
+        result = await tool.execute(
+            {"path": "app.py", "old_string": "a", "new_string": "b", "replace_all": True},
+            tool_context,
+        )
+        assert result.status == "ok"
+        assert result.data["replacements"] == 3
+        assert (tool_context.workspace / "app.py").read_text() == "b\nb\nb\n"
+
+    async def test_nonexistent_file(self, tool_context: ToolContext) -> None:
+        tool = EditFileTool()
+        result = await tool.execute(
+            {"path": "ghost.py", "old_string": "a", "new_string": "b"}, tool_context
+        )
+        assert result.status == "error"
+        assert "not found" in result.display
+
+    async def test_noop_edit_rejected(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "app.py").write_text("same\n")
+        tool = EditFileTool()
+        result = await tool.execute(
+            {"path": "app.py", "old_string": "same", "new_string": "same"}, tool_context
+        )
+        assert result.status == "error"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_search.py
+++ b/tests/test_tools/test_search.py
@@ -1,0 +1,78 @@
+"""Tests for search and discovery tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from noscope.tools.base import ToolContext
+from noscope.tools.search import FindFilesTool, SearchFilesTool
+
+
+@pytest.mark.asyncio
+class TestSearchFilesTool:
+    async def test_finds_matches_with_locations(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "app.py").write_text("import os\ndef main():\n    pass\n")
+        (tool_context.workspace / "util.py").write_text("def helper():\n    return 1\n")
+        tool = SearchFilesTool()
+        result = await tool.execute({"pattern": r"def \w+\("}, tool_context)
+        assert result.status == "ok"
+        assert "app.py:2:" in result.display
+        assert "util.py:1:" in result.display
+        assert result.data["count"] == 2
+
+    async def test_glob_filter(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "a.py").write_text("target\n")
+        (tool_context.workspace / "b.txt").write_text("target\n")
+        tool = SearchFilesTool()
+        result = await tool.execute({"pattern": "target", "glob": "*.py"}, tool_context)
+        assert "a.py" in result.display
+        assert "b.txt" not in result.display
+
+    async def test_no_matches(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "a.py").write_text("nothing here\n")
+        tool = SearchFilesTool()
+        result = await tool.execute({"pattern": "zzz"}, tool_context)
+        assert result.status == "ok"
+        assert result.data["count"] == 0
+
+    async def test_invalid_regex(self, tool_context: ToolContext) -> None:
+        tool = SearchFilesTool()
+        result = await tool.execute({"pattern": "("}, tool_context)
+        assert result.status == "error"
+
+    async def test_skips_ignored_dirs(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / ".git").mkdir()
+        (tool_context.workspace / ".git" / "config").write_text("target\n")
+        (tool_context.workspace / "real.py").write_text("target\n")
+        tool = SearchFilesTool()
+        result = await tool.execute({"pattern": "target"}, tool_context)
+        assert "real.py" in result.display
+        assert ".git" not in result.display
+
+    async def test_respects_max_results(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "many.txt").write_text("x\n" * 10)
+        tool = SearchFilesTool()
+        result = await tool.execute({"pattern": "x", "max_results": 3}, tool_context)
+        assert result.data["count"] == 3
+        assert result.data["truncated"] is True
+
+
+@pytest.mark.asyncio
+class TestFindFilesTool:
+    async def test_glob_recursive(self, tool_context: ToolContext) -> None:
+        (tool_context.workspace / "src").mkdir()
+        (tool_context.workspace / "src" / "a.py").write_text("")
+        (tool_context.workspace / "b.py").write_text("")
+        (tool_context.workspace / "c.txt").write_text("")
+        tool = FindFilesTool()
+        result = await tool.execute({"pattern": "**/*.py"}, tool_context)
+        assert "b.py" in result.display
+        assert "src/a.py" in result.display
+        assert "c.txt" not in result.display
+        assert result.data["count"] == 2
+
+    async def test_no_match(self, tool_context: ToolContext) -> None:
+        tool = FindFilesTool()
+        result = await tool.execute({"pattern": "**/*.rs"}, tool_context)
+        assert result.status == "ok"
+        assert result.data["count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,7 @@ wheels = [
 name = "ast-serialize"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/6a/a68c7f823e67714393060a0f232b0d75e0b2d2f1a7aef0633f7007411804/ast_serialize-0.7.0.tar.gz", hash = "sha256:934c0920454381b0beb46a5dc0af114d48699a44537b97282c2346a23990713d", size = 845507, upload-time = "2026-08-06T14:07:38.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/15/3b0e4edec45fd31a55243e37263236946cdfe6901e3f8cff934a443eddc0/ast_serialize-0.7.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:55e524f1329e2ee3f17d497b45d16a069afd2020b324ef6f32d21831e0b47a81", size = 1177653, upload-time = "2026-08-06T14:06:07.738Z" },
     { url = "https://files.pythonhosted.org/packages/e8/3d/ecb5f748a3ff50153b5956200a8eea265797de98ebe7b6ca9f8f28d65f08/ast_serialize-0.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8dcbb7b94e5cb8c718f4f5c310b608fa73cd3714b819fe1995b20acfa6847689", size = 1167069, upload-time = "2026-08-06T14:06:09.49Z" },
@@ -111,6 +112,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/46/a316dddccecedafea3002a9ed1cd6666ab5e64c3094951625b5a1ef95a1c/ast_serialize-0.7.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:95219c374d0ac76639b26b66cca26e8cb090bf8c515d6bc376af484514d10151", size = 1509449, upload-time = "2026-08-06T14:07:23.53Z" },
     { url = "https://files.pythonhosted.org/packages/81/34/c58f49cc9da933af6ee0f802eb780c48648ae9d0ee9188cb802c10dce29f/ast_serialize-0.7.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1e71d8879b8c3480eb461128bbf0d5ff87f5ce368fcdb10c850a95010aa5ece4", size = 1505368, upload-time = "2026-08-06T14:07:25.101Z" },
     { url = "https://files.pythonhosted.org/packages/1f/ce/4c5a9ff4e2851ec38ecb8aeef8cb7e0a02308616279c04429342e12985f4/ast_serialize-0.7.0-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:85fa81ed590407c6ef6f85cac8e451051bf2623ecd875c4e124af8b8251de3ac", size = 1563486, upload-time = "2026-08-06T14:07:26.937Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/f239d17f902a2ce39da8e6dc034f48f45da93dfda658fa88189a02763510/ast_serialize-0.7.0-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:fd018e40c9462235a1d2d101b420cff6c577e5a51b2954ffc05b907a0807defc", size = 1427995, upload-time = "2026-08-06T14:07:28.773Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6c/024f58d8b52ce29717c54a578f0bbd844439fcb8eb442596e756fd6eaffe/ast_serialize-0.7.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:90a614b8c844620473b7445d31a2a6bf9500fdc4a8d1e2b6a70d40f38beea0e5", size = 1454215, upload-time = "2026-08-06T14:07:30.526Z" },
+    { url = "https://files.pythonhosted.org/packages/12/48/f046778df64acef37a36a7338a9bdaa795f46b19d35a4d28bddcd8dfaec7/ast_serialize-0.7.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:e6cfb423d4a14d774b3b82f6509adbc5da065246b6ec679221ad133820e0f7f4", size = 868142, upload-time = "2026-08-06T14:07:32.139Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fc/c862cc8d4d8d749f360035baa245fb3098b8b934c57122c0222ac5078762/ast_serialize-0.7.0-cp39-abi3-win32.whl", hash = "sha256:e818854e8521846f5a5271b1488c490231b8b6e02d0158ec42e57bc06dd764f0", size = 1068874, upload-time = "2026-08-06T14:07:33.895Z" },
+    { url = "https://files.pythonhosted.org/packages/92/33/e846301850c18fa31598e342bb80b32f380c1bce285df571f5c3711960ff/ast_serialize-0.7.0-cp39-abi3-win_amd64.whl", hash = "sha256:942921b81440d3ea57f90370d5d29bf28dc81c0778e26b736013e83c7b258023", size = 1111845, upload-time = "2026-08-06T14:07:35.308Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/4ee99be6306e72fac6051461794e5cd7895bbbdafe5b921a9a8c4b6fde1c/ast_serialize-0.7.0-cp39-abi3-win_arm64.whl", hash = "sha256:43b73cf3924aa49f241be6e5f6a19943c8e2e07a2786fc719cacaa54ac6fd2d5", size = 1083656, upload-time = "2026-08-06T14:07:36.828Z" },
 ]
 
 [[package]]
@@ -510,7 +517,7 @@ wheels = [
 
 [[package]]
 name = "noscope"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -548,7 +555,7 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "typer", extras = ["all"] },
+    { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Heads up: PR #7 only merged Phase 0–1

PR #7 was merged at the Phase-1 commit, so `main` is still **0.1.0** with only the un-break + LLM-modernization work. **The bulk of the revival — Phase 2, 3, 4, and 0.2.0 — never landed.** This PR brings it in (main has been merged into the branch, so the diff is clean).

## What's in this PR

**Phase 2 — owned harness capability gaps**
- `edit_file` (uniqueness-guarded string replacement + diff, replacing whole-file rewrites; same-file mutations serialized so edits can't race)
- `search_files` (grep) + `find_files` (glob) + `read_file` line windows
- Docker sandbox correctness: base64 writes (fixing heredoc corruption) and path validation (closing traversal/injection)

**Phase 3 — verification that actually verifies**
- HARDEN checks assert expected output (`cmd: … ==> <text>`), not just exit 0
- VERIFY runs the agent's proof command itself instead of trusting a `VERIFIED:` string
- A failing check gets a bounded auto-repair-and-retry; the re-run is the authority

**Phase 4 — spend cap + release + docs**
- `--token-budget`: a token spend cap enforced alongside the timebox
- Cache-aware cost reporting (cached-read tokens + dollars saved)
- `CHANGELOG.md`, `RELEASE.md`, version **0.2.0**, `typer[all]` → `typer` dep fix

**Docs (new, for an interview-grade project)**
- `ARCHITECTURE.md` — how it works and why, with four Mermaid diagrams (pipeline, multi-agent supervisor + audit feed, capability-gated dispatch, execute-don't-trust VERIFY), a design-decisions table, and honest limitations
- README `Design highlights` section, a sample event-log excerpt, and deep-doc links

## Testing

- [x] `make test` — **195 passing** (from 152 on `main`)
- [x] `make lint` — ruff clean
- [x] `make typecheck` — `mypy --strict` clean

## Known limitations (in `PLAN.md` / `RELEASE.md`)

No context management yet; Docker image Python-only + git-on-host under `--sandbox`; `MAX_WORKERS` fixed at 2; live end-to-end validated by hand (no key in CI). Acceptable for a 0.2.x preview, not a 1.0 claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuiFDEHD39RSYL6nR4wfFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuiFDEHD39RSYL6nR4wfFf)_