### PR TITLE
Prove the harness works without an API key: E2E tests, provider shape tests, CI smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
 
@@ -28,8 +29,48 @@ jobs:
       - name: Lint
         run: uv run ruff check noscope/ tests/
 
+      - name: Format check
+        run: uv run ruff format --check noscope/ tests/
+
       - name: Type check
         run: uv run mypy noscope/
 
       - name: Test
         run: uv run pytest tests/ -v --tb=short
+
+  smoke:
+    # Drives the real CLI through all six phases with a scripted provider, so a
+    # broken pipeline fails here even when every unit test still passes. No API
+    # key, no network, no tokens.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Dry run the full pipeline
+        run: uv run noscope run --spec examples/hello-flask.md --time 3m --dir /tmp/smoke --yes --dry-run
+
+      - name: Assert the run produced its artifacts
+        run: |
+          test -f /tmp/smoke/index.html
+          run_dir=$(ls -d .noscope/runs/* | head -1)
+          test -s "$run_dir/handoff.md"
+          test -s "$run_dir/events.jsonl"
+          grep -q '"type": *"run.complete"' "$run_dir/events.jsonl"
+
+      - name: Doctor passes its required checks
+        env:
+          NOSCOPE_ANTHROPIC_API_KEY: ci-placeholder
+        run: uv run noscope doctor
+
+      - name: Doctor fails loudly when no key is configured
+        run: |
+          if uv run noscope doctor; then
+            echo "doctor exited 0 with no API key configured" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# CI only reads the repo; nothing here publishes, comments, or writes.
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,28 @@ Everything that could run long consults it:
 The deadline is *cooperative* — it doesn't kill threads, it gives every loop a
 cheap check so they wind down and the pipeline advances to HANDOFF.
 
+### The hole cooperative checking leaves
+
+Checks happen *between* iterations, so nothing consults the deadline while a
+request is in flight — and both SDKs default to a 600-second read timeout with
+retries stacked on top. One stalled call could therefore outlast a five-minute
+timebox entirely. That isn't a degraded guarantee; it's no guarantee.
+
+So every provider call is wrapped by
+[`DeadlineBoundProvider`](noscope/llm/bounded.py), which caps it at
+`NOSCOPE_REQUEST_TIMEOUT` (120s) or the remaining timebox, whichever is
+smaller. Two properties make it worth doing this way:
+
+- The `wait_for` sits *outside* the SDK call, so the bound covers the SDK's
+  internal retries too, not just one attempt.
+- It's applied once, in the orchestrator, so every call site — plan, agents,
+  harden, verify, handoff — is covered without any of them knowing about it.
+
+There's one deliberate exception: a floor, because HANDOFF runs *after* the
+deadline by design. The floor applies to the remaining timebox rather than to
+the configured cap, so a deliberately small `NOSCOPE_REQUEST_TIMEOUT` is still
+honored — it guards against an expired deadline, not against a choice.
+
 ## Multi-agent build
 
 BUILD is the most concurrent part. The [`Supervisor`](noscope/supervisor.py)
@@ -266,7 +288,8 @@ rather than aspirational.
 | **Own agent harness, not a wrapper over the Claude Agent SDK** | The orchestration *is* the project. Wrapping the SDK (Claude Code as a library) would make it "Claude Code with a timer" and give up provider-agnosticism. See [`PLAN.md`](PLAN.md) §3 for the full trade-off. |
 | **Execute checks, don't trust the model** | Model-as-oracle verification is the worst failure mode for a demo. HARDEN and VERIFY both ground their verdicts in commands the harness runs. |
 | **`edit_file` with a uniqueness guard, not whole-file rewrites** | Whole-file writes were the dominant token cost and caused last-write-wins clobbering; an edit that would match ambiguously *fails* rather than changing the wrong region. |
-| **Cooperative deadline, not forced cancellation** | Cheap per-loop checks wind agents down cleanly so the pipeline always reaches HANDOFF, instead of killing work mid-write. |
+| **Cooperative deadline, not forced cancellation** | Cheap per-loop checks wind agents down cleanly so the pipeline always reaches HANDOFF, instead of killing work mid-write. The one thing cooperation can't cover — a request already in flight — is bounded at the provider boundary instead. |
+| **Agents tolerate a few failed LLM calls, then stand down** | Tasks are partitioned into per-worker streams, so an exception escaping one agent used to silently cost that worker every remaining task. Three consecutive failures is enough to distinguish a blip from an outage without burning the timebox retrying. |
 | **Capability gating + dedicated tools over raw bash** | Typed, gated tools can be path-checked, approved, logged, and redacted; an opaque bash string can't. |
 | **Thin, single-file LLM layer** | Owning the harness means owning API churn; keeping the provider layer tiny makes a model/API change a one-line default, not a refactor. |
 
@@ -280,5 +303,8 @@ Honest boundaries (tracked in [`PLAN.md`](PLAN.md) and [`RELEASE.md`](RELEASE.md
   for provider rate limits.
 - The shell safety filter is a deny-list — a backstop, not a sandbox. Untrusted
   specs should use `--sandbox`.
-- Live end-to-end behavior is validated by hand (see `RELEASE.md`), not in CI —
-  CI has no API key.
+- Live end-to-end behavior against a real model is validated by hand (see
+  `RELEASE.md`), since CI has no API key. CI does run the full pipeline on
+  every push via `--dry-run`, so the harness itself — CLI, capability gating,
+  tool dispatch, phase budgets, acceptance checks, reporting — is covered; what
+  isn't covered is model quality and the live provider wire format.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,8 +96,13 @@ Three design decisions worth calling out:
   JSON, missing entry point) are injected into the relevant worker's next turn
   as a correction, rather than accumulating in a log nobody reads.
 
-Concurrency is bounded at `MAX_WORKERS = 2` — a deliberate, conservative choice
-to stay under provider rate limits with several concurrent LLM streams.
+Concurrency defaults to 2 workers — a deliberate, conservative choice to stay
+under provider rate limits with several concurrent LLM streams — and is
+configurable with `--workers`.
+
+The audit agent isn't just an existence check: it compile-checks Python (and
+parses JavaScript where `node` is available), so a file that cannot even parse
+is surfaced to the worker that wrote it while there's still time to fix it.
 
 ## Tools and capability gating
 
@@ -170,6 +175,25 @@ sequenceDiagram
 The verdict is grounded in an executed command every time. A model that asserts
 success without a passing command simply doesn't get a "verified" run.
 
+## Context management
+
+Agent loops append every turn to a message list and can run for hundreds of
+iterations, with whole-file reads and large command outputs landing in context.
+Unbounded, that eventually fails on context length — and a failed request costs
+that worker its remaining tasks. [`context.py`](noscope/context.py) applies two
+cheap defenses before each request:
+
+- **`truncate_tool_output`** caps any single tool result, keeping the head and
+  tail (errors live at one end or the other) with a note of what was dropped.
+- **`trim_history`** drops the oldest turns once the conversation exceeds a
+  character budget, always keeping the system prompt and the original briefing,
+  and leaving a note telling the agent to re-read files rather than trust
+  memory of dropped output.
+
+The subtle invariant: a tool result whose assistant turn was dropped is an *API
+error*, not merely lost context. So the kept tail may never begin with a `tool`
+message — enforced in code and swept across many conversation lengths in tests.
+
 ## Two budgets: time and tokens
 
 NoScope's promise is a *spend cap*. It enforces that in both dimensions:
@@ -230,12 +254,10 @@ rather than aspirational.
 
 Honest boundaries (tracked in [`PLAN.md`](PLAN.md) and [`RELEASE.md`](RELEASE.md)):
 
-- No conversation-context management yet — very long runs can approach context
-  limits.
-- The Docker sandbox uses a Python-only image; git tools still act on the host
-  tree during `--sandbox` runs, and the container exec timeout is not
-  deadline-aware.
-- `MAX_WORKERS` is fixed at 2.
+- The Docker sandbox uses a Python-only image and git tools still act on the
+  host tree during `--sandbox` runs.
+- Worker count defaults to 2 (raise with `--workers`), tuned conservatively
+  for provider rate limits.
 - The shell safety filter is a deny-list — a backstop, not a sandbox. Untrusted
   specs should use `--sandbox`.
 - Live end-to-end behavior is validated by hand (see `RELEASE.md`), not in CI —

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,6 +104,26 @@ The audit agent isn't just an existence check: it compile-checks Python (and
 parses JavaScript where `node` is available), so a file that cannot even parse
 is surfaced to the worker that wrote it while there's still time to fix it.
 
+### Write conflicts
+
+Partitioning reduces overlap; it can't eliminate it, because the file
+assignment ultimately comes from a model. So writes are also tracked at
+runtime. A [`WriteLedger`](noscope/conflicts.py) records the last writer of
+each path; when a *different* agent overwrites it with *different* content,
+three things happen:
+
+1. The clobbering agent gets a warning appended to its tool output — the only
+   channel back into its conversation — telling it to re-read before editing.
+2. A `write.conflict` event is logged.
+3. The handoff report gets a "Parallel Write Conflicts" section, appended
+   after generation so the model writing the report cannot omit it.
+
+Writes are warned about, not blocked. Overlap is sometimes legitimate — a
+worker adding a dependency to a manifest the setup agent created — and a
+harness that refuses writes mid-build would fail more runs than it saves. The
+failure being defended against is the silent one: two workers both "succeed",
+last write wins, and the run reports a clean build over discarded work.
+
 ## Tools and capability gating
 
 Agents don't touch the machine directly. Every action goes through a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ review and roadmap.
   harness blocked until the orphan happened to exit. Children now run in their
   own session and a timeout terminates the whole group. Same fix for the
   `docker exec` client and for Ctrl+C on `--serve`.
+- **BUILD no longer idles waiting for the audit agent.** The auditor loops
+  until the phase is nearly over, and it was gathered together with the
+  workers — so a build that genuinely finished early still blocked for the
+  rest of BUILD's budget before HARDEN could start (on a 30-minute run, up to
+  ~16 wasted minutes). It's now cancelled once the workers return; findings
+  are read from the shared feed, so none are lost.
 - `noscope doctor` exits non-zero when a requirement is missing, so it works as
   a gate — and no longer counts "OpenAI key not set" as a failure when a valid
   Anthropic key is present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ review and roadmap.
   harness blocked until the orphan happened to exit. Children now run in their
   own session and a timeout terminates the whole group. Same fix for the
   `docker exec` client and for Ctrl+C on `--serve`.
+- **A stalled model request can no longer outrun the timebox.** The deadline is
+  cooperative — checked between agent iterations — so it could not interrupt a
+  request in flight, and both SDKs default to a 600s read timeout with retries
+  on top. Every provider call now goes through a `DeadlineBoundProvider` capped
+  at `NOSCOPE_REQUEST_TIMEOUT` (120s) or the remaining timebox, whichever is
+  smaller, with a floor so HANDOFF can still produce its report.
 - **BUILD no longer idles waiting for the audit agent.** The auditor loops
   until the phase is nearly over, and it was gathered together with the
   workers — so a build that genuinely finished early still blocked for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,20 @@ review and roadmap.
   instead of blocking on a foreground server, honoring the hard-deadline promise.
 - Docker sandbox: file writes use base64 (the old heredoc corrupted backslashes
   and could truncate on content); all container paths are validated against
-  traversal and shell-injection.
+  traversal and shell-injection; container command timeouts are now
+  deadline-aware like the host shell tool.
+- `noscope new` writes its spec with a real YAML dumper — a project name or
+  constraint containing a quote or colon previously produced an invalid file —
+  and slugifies the filename safely.
 
 ### Added
 
+- **Context management:** tool results are capped and the conversation is
+  trimmed to a character budget before each request, so long runs no longer
+  risk failing on context length (trimming never orphans a tool result).
+- **Real audit checks:** the audit agent compile-checks Python (and parses
+  JavaScript when `node` is available), so broken code is caught during BUILD
+  and fed back to workers instead of only existing files being counted.
 - **Editing and discovery tools:** `edit_file` (exact-string replacement with a
   uniqueness guard + diff, replacing whole-file rewrites), `search_files`
   (regex/grep), `find_files` (glob), and `read_file` line windows.
@@ -42,8 +52,8 @@ review and roadmap.
   dollars prompt caching saved.
 - Structured outputs, prompt caching, adaptive thinking + effort, and SDK-native
   retries in the LLM layer; a cheaper model (Haiku) for the handoff report.
-- `--serve` flag; `NOSCOPE_FAST_MODEL`, `NOSCOPE_MAX_TOKENS`, `NOSCOPE_EFFORT`,
-  `NOSCOPE_TOKEN_BUDGET` settings.
+- `--serve` and `--workers` flags; `NOSCOPE_FAST_MODEL`, `NOSCOPE_MAX_TOKENS`,
+  `NOSCOPE_EFFORT`, `NOSCOPE_TOKEN_BUDGET`, `NOSCOPE_MAX_WORKERS` settings.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ review and roadmap.
 
 ### Added
 
+- **`--dry-run`:** exercises the entire pipeline — tools, acceptance checks,
+  verification, event log, handoff report — with no API calls and no tokens,
+  so the harness can be smoke-tested before spending anything.
+- **`doctor --live`:** makes one minimal API call so a bad key or wrong model
+  fails in seconds rather than part-way through a build.
+- **Actionable API errors:** auth failures, unknown models, rate limits,
+  overload, and network errors now print a diagnosis and the fix instead of a
+  bare traceback.
 - **Context management:** tool results are capped and the conversation is
   trimmed to a character budget before each request, so long runs no longer
   risk failing on context length (trimming never orphans a tool result).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ review and roadmap.
   correct phase on tool events.
 - The planner no longer swallows API errors as "invalid plan".
 - Git subprocesses run with the sanitized environment (API keys were visible).
+- **Timed-out commands no longer leak their process trees.** Killing the shell
+  left grandchildren (a dev server, say) running as orphans still holding the
+  output pipes, so the port stayed bound for the rest of the run and the
+  harness blocked until the orphan happened to exit. Children now run in their
+  own session and a timeout terminates the whole group. Same fix for the
+  `docker exec` client and for Ctrl+C on `--serve`.
+- `noscope doctor` exits non-zero when a requirement is missing, so it works as
+  a gate — and no longer counts "OpenAI key not set" as a failure when a valid
+  Anthropic key is present.
 - App launch is opt-in via `--serve`; by default NoScope prints the run command
   instead of blocking on a foreground server, honoring the hard-deadline promise.
 - Docker sandbox: file writes use base64 (the old heredoc corrupted backslashes
@@ -58,6 +67,15 @@ review and roadmap.
   the same way the timebox does — the spend guarantee is now true in tokens too.
 - **Cache-aware cost reporting:** the summary shows cached-read tokens and the
   dollars prompt caching saved.
+- **Write-conflict detection:** a shared `WriteLedger` records the last writer
+  of every file, so when parallel agents overwrite each other the clobbering
+  agent is warned in-conversation, a `write.conflict` event is logged, and the
+  handoff report names the affected files. Previously two workers could both
+  "succeed" while one's work was silently discarded.
+- **Sandbox preflight:** `--sandbox` verifies Docker is actually usable before
+  PLAN instead of failing part-way through a build, and distinguishes
+  not-installed from daemon-down. `doctor` reports the daemon, not just the
+  binary on `PATH`.
 - Structured outputs, prompt caching, adaptive thinking + effort, and SDK-native
   retries in the LLM layer; a cheaper model (Haiku) for the handoff report.
 - `--serve` and `--workers` flags; `NOSCOPE_FAST_MODEL`, `NOSCOPE_MAX_TOKENS`,
@@ -70,6 +88,10 @@ review and roadmap.
   with version floors.
 - Example specs modernized (`python3`, expected-output checks) and README given
   an honest "When to use NoScope" section.
+- CI now checks formatting and runs a no-key smoke job that drives the real CLI
+  through all six phases, so a broken pipeline fails CI even when every unit
+  test passes. Provider request/response shapes are covered by mocked-SDK tests
+  — previously no SDK call was asserted anywhere.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,19 @@ NoScope executes LLM-generated code on your machine. It ships with multiple laye
 - **Docker sandbox** — optional container isolation with resource limits
 - **Secret redaction** — API keys are scrubbed from event logs
 
+### About `--sandbox`
+
+`--sandbox` runs every agent action inside a container with **no host mounts** —
+files are copied in at start and back out at stop — under a memory/CPU cap, with
+all Linux capabilities dropped except the handful a build needs, and
+`no-new-privileges` set. It needs a reachable Docker daemon; `noscope doctor`
+tells you whether you have one, and `run --sandbox` checks before spending a
+single token rather than failing mid-build.
+
+Without `--sandbox`, commands run on the host. They are still capability-gated
+and safety-filtered, but a deny-list is not a security boundary — use
+`--sandbox` for specs you did not write yourself.
+
 See [SECURITY.md](.github/SECURITY.md) for the full security model, known limitations, and how to report vulnerabilities.
 
 ---

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ See the [`examples/`](examples/) directory for more spec templates.
 uv run noscope run --spec <path> --time <duration> --dir <output>
     [--provider anthropic|openai] [--model <model>]
     [--sandbox] [--danger] [--yes] [--serve]
+    [--token-budget <n>] [--workers <n>]
 
 uv run noscope new             # Create and run a project interactively
 uv run noscope doctor          # Check environment and API keys
@@ -232,6 +233,8 @@ uv run noscope init            # Create a spec file template
 | `--danger` | Bypass safety filters (use only with trusted specs) |
 | `--yes`, `-y` | Auto-approve all capability requests |
 | `--serve` | After a verified build, launch the app and stream output (blocks until Ctrl+C) |
+| `--token-budget` | Stop the build once this many total tokens are used (a spend cap alongside the timebox) |
+| `--workers` | Parallel build workers (default 2) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ export NOSCOPE_OPENAI_API_KEY="your-key-here"
 uv run noscope doctor
 ```
 
+### Try it with no API calls first
+
+```bash
+uv run noscope run --spec examples/static-portfolio.md --time 3m --dir /tmp/demo --yes --dry-run
+```
+
+`--dry-run` exercises the entire pipeline — workspace setup, capability
+gating, tool execution, acceptance checks, verification, and the handoff
+report — without contacting any provider or spending a token. If a dry run
+completes, the harness works; anything that fails on a live run is about the
+model or the API, not the plumbing.
+
+### Confirm your key and model work
+
+```bash
+uv run noscope doctor --live
+```
+
+`--live` makes one tiny API call, so a bad key or a wrong `--model` fails in
+seconds instead of part-way through a real build.
+
 ### Run your first build
 
 ```bash
@@ -219,6 +240,7 @@ uv run noscope run --spec <path> --time <duration> --dir <output>
 
 uv run noscope new             # Create and run a project interactively
 uv run noscope doctor          # Check environment and API keys
+uv run noscope doctor --live   # ...and prove the key/model work with one API call
 uv run noscope init            # Create a spec file template
 ```
 
@@ -235,6 +257,7 @@ uv run noscope init            # Create a spec file template
 | `--serve` | After a verified build, launch the app and stream output (blocks until Ctrl+C) |
 | `--token-budget` | Stop the build once this many total tokens are used (a spend cap alongside the timebox) |
 | `--workers` | Parallel build workers (default 2) |
+| `--dry-run` | Run the full pipeline with no API calls and no tokens spent |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ output" guarantee is enforced. A few decisions worth a closer look
   tokens the same way. The product's promise is a spend guarantee — enforced in
   both dimensions.
 
+  Cooperative checks happen *between* iterations, so they can't interrupt a
+  request already in flight — and both SDKs default to a 600-second read
+  timeout, with retries on top. Every provider call is therefore wrapped by a
+  `DeadlineBoundProvider` that caps it at `NOSCOPE_REQUEST_TIMEOUT` (120s) or
+  the remaining timebox, whichever is smaller. That's what makes the deadline a
+  guarantee rather than a best effort. The one deliberate exception is a floor
+  so HANDOFF — which runs *after* the deadline by design — can still write its
+  report.
+
 - **Parallel build with dependency-aware partitioning.** A supervisor splits
   setup into concurrent structure + deps agents, then partitions the remaining
   tasks with union-find over the dependency graph (+ topological sort) so

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,8 +35,7 @@ and the final summary shows a cost (and cache savings on Anthropic).
 These are tracked in `PLAN.md` and are acceptable for a 0.2.x preview, not for a
 stability guarantee:
 
-- No conversation-context management yet — very long runs can hit context limits.
-- `--sandbox` (Docker) uses a Python-only image; git tools still act on the host
-  tree during sandbox runs, and the exec timeout is not deadline-aware.
-- `MAX_WORKERS` is fixed at 2.
+- `--sandbox` (Docker) uses a Python-only image and git tools still act on the
+  host tree during sandbox runs.
+- Worker count defaults to 2 (`--workers` to raise).
 - Live end-to-end behavior is validated by hand, not in CI.

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -83,7 +84,9 @@ class BuildAgent:
         self.agent_id = agent_id
         self.provider = provider
         self.dispatcher = dispatcher
-        self.context = context
+        # Own copy of the context stamped with this agent's id, so the write
+        # ledger (which stays shared) can attribute each write to its author.
+        self.context = replace(context, agent_id=agent_id)
         self.event_log = event_log
         self.deadline = deadline
         self.ui = ui

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
     from noscope.ui.console import ConsoleUI
 
 MAX_AGENT_ITERATIONS = 200
+# Consecutive failed LLM calls before an agent stands down. A transient blip
+# shouldn't cost a worker every remaining task in its stream, but a persistent
+# failure shouldn't burn the timebox retrying either.
+MAX_CONSECUTIVE_LLM_FAILURES = 3
 TIME_STATUS_INTERVAL = 3  # Inject time status every N tool calls
 
 
@@ -138,6 +142,7 @@ class BuildAgent:
             )
         )
 
+        consecutive_failures = 0
         for _iteration in range(MAX_AGENT_ITERATIONS):
             if self.deadline.is_expired() or self.deadline.should_transition(Phase.BUILD):
                 break
@@ -171,7 +176,30 @@ class BuildAgent:
             # fails on length would cost this worker its remaining tasks.
             messages = trim_history(messages)
 
-            response = await self.provider.complete(messages, tools=tool_schemas)
+            try:
+                response = await self.provider.complete(messages, tools=tool_schemas)
+            except Exception as e:  # noqa: BLE001 — logged and bounded below
+                # A blip on one call must not cost this worker every remaining
+                # task in its stream. Retry a couple of times, then stand down
+                # and let the other workers and HANDOFF carry on.
+                # (CancelledError is a BaseException, so it still propagates.)
+                consecutive_failures += 1
+                self.event_log.emit(
+                    phase=Phase.BUILD.value,
+                    event_type="agent.llm_error",
+                    summary=f"[{self.agent_id}] LLM call failed "
+                    f"({consecutive_failures}/{MAX_CONSECUTIVE_LLM_FAILURES}): {e}",
+                    data={
+                        "agent_id": self.agent_id,
+                        "error": str(e),
+                        "type": type(e).__name__,
+                    },
+                )
+                if consecutive_failures >= MAX_CONSECUTIVE_LLM_FAILURES:
+                    break
+                continue
+
+            consecutive_failures = 0
             if self.tokens:
                 self.tokens.add(response.usage)
 

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
+from noscope.context import trim_history, truncate_tool_output
 from noscope.deadline import Deadline, Phase
 from noscope.llm.base import LLMProvider, Message, ToolCall, ToolSchema
 from noscope.logging.events import EventLog
@@ -162,6 +163,10 @@ class BuildAgent:
             if audit_message:
                 messages.append(Message(role="user", content=audit_message))
 
+            # Keep the conversation inside the context budget — a request that
+            # fails on length would cost this worker its remaining tasks.
+            messages = trim_history(messages)
+
             response = await self.provider.complete(messages, tools=tool_schemas)
             if self.tokens:
                 self.tokens.add(response.usage)
@@ -292,7 +297,7 @@ class BuildAgent:
             results.append(
                 Message(
                     role="tool",
-                    content=result.display or json.dumps(result.data),
+                    content=truncate_tool_output(result.display or json.dumps(result.data)),
                     tool_call_id=tc.id,
                 )
             )
@@ -306,7 +311,7 @@ class BuildAgent:
         result = await self.dispatcher.dispatch(tc.name, tc.arguments, self.context)
         return Message(
             role="tool",
-            content=result.display or json.dumps(result.data),
+            content=truncate_tool_output(result.display or json.dumps(result.data)),
             tool_call_id=tc.id,
         )
 

--- a/noscope/agents.py
+++ b/noscope/agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from noscope.context import trim_history, truncate_tool_output
@@ -405,7 +406,55 @@ class AuditAgent:
                     {"type": "invalid_requirements", "message": "requirements.txt unreadable"}
                 )
 
+        findings.extend(await self._syntax_findings(workspace))
+
         if self.ui and not findings:
             self.ui.tool_activity("audit", "checks passed", self.deadline)
+
+        return findings
+
+    async def _syntax_findings(self, workspace: Path) -> list[dict[str, Any]]:
+        """Compile-check source files so broken code is caught during BUILD.
+
+        Existence checks alone let a worker keep building on a file that cannot
+        even parse; a syntax error surfaced now is fed back through the audit
+        feed while there is still time to fix it.
+        """
+        findings: list[dict[str, Any]] = []
+
+        if any(workspace.rglob("*.py")):
+            # compileall is quiet on success and names the offending file on failure.
+            result = await self.dispatcher.dispatch(
+                "exec_command",
+                {"command": "python3 -m compileall -q .", "timeout": 20},
+                self.context,
+            )
+            if result.status == "error":
+                findings.append(
+                    {
+                        "type": "syntax_error",
+                        "message": f"Python file(s) fail to compile: {result.display[:300]}",
+                    }
+                )
+
+        js_files = [p for p in workspace.rglob("*.js") if "node_modules" not in p.parts]
+        if js_files:
+            rel = " ".join(f"'{p.relative_to(workspace)}'" for p in js_files[:20])
+            result = await self.dispatcher.dispatch(
+                "exec_command",
+                # Skip silently when node isn't available rather than crying wolf.
+                {
+                    "command": f"command -v node >/dev/null || exit 0; node --check {rel}",
+                    "timeout": 20,
+                },
+                self.context,
+            )
+            if result.status == "error":
+                findings.append(
+                    {
+                        "type": "syntax_error",
+                        "message": f"JavaScript file(s) fail to parse: {result.display[:300]}",
+                    }
+                )
 
         return findings

--- a/noscope/cli.py
+++ b/noscope/cli.py
@@ -106,12 +106,15 @@ def doctor(
     """Check environment for NoScope requirements."""
     console.print(f"[bold]NoScope Doctor[/bold] v{__version__}\n")
 
-    checks = []
+    # (name, ok, detail, required). Only `required` checks decide the exit code;
+    # the rest are reported for context. Deriving that from the name — the old
+    # `"optional" not in name` — made every informational row a hard failure.
+    checks: list[tuple[str, bool, str, bool]] = []
 
     # Python version
     v = sys.version_info
     ok = v >= (3, 12)
-    checks.append(("Python ≥ 3.12", ok, f"{v.major}.{v.minor}.{v.micro}"))
+    checks.append(("Python ≥ 3.12", ok, f"{v.major}.{v.minor}.{v.micro}", True))
 
     # API keys — check env vars and .env file
     import os
@@ -123,13 +126,16 @@ def doctor(
         os.environ.get("NOSCOPE_ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
     )
     has_openai = bool(os.environ.get("NOSCOPE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY"))
-    checks.append(("Anthropic API key", has_anthropic, "set" if has_anthropic else "not set"))
-    checks.append(("OpenAI API key", has_openai, "set" if has_openai else "not set"))
-    checks.append(("At least one API key", has_anthropic or has_openai, ""))
+    # Either key alone is enough, so the per-provider rows are informational.
+    checks.append(
+        ("Anthropic API key", has_anthropic, "set" if has_anthropic else "not set", False)
+    )
+    checks.append(("OpenAI API key", has_openai, "set" if has_openai else "not set", False))
+    checks.append(("At least one API key", has_anthropic or has_openai, "", True))
 
     # Git
     git_ok = shutil.which("git") is not None
-    checks.append(("git", git_ok, shutil.which("git") or "not found"))
+    checks.append(("git", git_ok, shutil.which("git") or "not found", True))
 
     # Docker — the binary existing says nothing about --sandbox working, so
     # check the daemon too. This is the exact check `run --sandbox` performs.
@@ -142,15 +148,16 @@ def doctor(
             "docker (optional, for --sandbox)",
             docker_ok,
             "daemon reachable" if docker_ok else "unusable — see below",
+            False,
         )
     )
 
     # uv
     uv_ok = shutil.which("uv") is not None
-    checks.append(("uv (optional)", uv_ok, shutil.which("uv") or "not found"))
+    checks.append(("uv (optional)", uv_ok, shutil.which("uv") or "not found", False))
 
-    for name, ok, detail in checks:
-        icon = "[green]✓[/green]" if ok else "[red]✗[/red]"
+    for name, ok, detail, required in checks:
+        icon = "[green]✓[/green]" if ok else ("[red]✗[/red]" if required else "[yellow]–[/yellow]")
         detail_str = f" ({detail})" if detail else ""
         console.print(f"  {icon} {name}{detail_str}")
 
@@ -158,7 +165,7 @@ def doctor(
         # Optional, so it doesn't fail the run — but say what's actually wrong.
         console.print(f"\n  [dim]{docker_problem}[/dim]")
 
-    all_ok = all(ok for name, ok, _ in checks if "optional" not in name)
+    all_ok = all(ok for _, ok, _, required in checks if required)
 
     if live:
         all_ok = _live_check() and all_ok
@@ -166,8 +173,10 @@ def doctor(
     console.print()
     if all_ok:
         console.print("[green]All checks passed![/green]")
-    else:
-        console.print("[yellow]Some checks failed. Fix the issues above.[/yellow]")
+        return
+    console.print("[yellow]Some checks failed. Fix the issues above.[/yellow]")
+    # Exit non-zero so `noscope doctor` is usable as a gate in scripts and CI.
+    raise typer.Exit(1)
 
 
 def _live_check() -> bool:

--- a/noscope/cli.py
+++ b/noscope/cli.py
@@ -41,8 +41,15 @@ def run(
         None, "--token-budget", help="Stop the build once this many total tokens are used"
     ),
     workers: int = typer.Option(None, "--workers", help="Parallel build workers (default 2)"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Exercise the whole pipeline with no API calls and no tokens spent",
+    ),
 ) -> None:
     """Build an MVP from a spec within a timebox."""
+    import os
+
     from noscope.config.settings import load_settings
     from noscope.ui.console import ConsoleUI
 
@@ -50,6 +57,14 @@ def run(
 
     if danger:
         ui.danger_warning()
+
+    if dry_run:
+        # No provider is contacted, so settings needn't carry a real key.
+        os.environ.setdefault("NOSCOPE_ANTHROPIC_API_KEY", "dry-run")
+        console.print(
+            "  [cyan]Dry run[/cyan] — no API calls, no tokens. "
+            "Exercises the full pipeline end to end.\n"
+        )
 
     try:
         settings = load_settings(
@@ -67,7 +82,7 @@ def run(
 
     from noscope.orchestrator import Orchestrator
 
-    orchestrator = Orchestrator(settings, console=console)
+    orchestrator = Orchestrator(settings, console=console, dry_run=dry_run)
     asyncio.run(
         orchestrator.run(
             spec_path=spec,
@@ -81,7 +96,13 @@ def run(
 
 
 @app.command()
-def doctor() -> None:
+def doctor(
+    live: bool = typer.Option(
+        False,
+        "--live",
+        help="Also make one tiny API call to prove the key and model actually work",
+    ),
+) -> None:
     """Check environment for NoScope requirements."""
     console.print(f"[bold]NoScope Doctor[/bold] v{__version__}\n")
 
@@ -124,11 +145,52 @@ def doctor() -> None:
         console.print(f"  {icon} {name}{detail_str}")
 
     all_ok = all(ok for name, ok, _ in checks if "optional" not in name)
+
+    if live:
+        all_ok = _live_check() and all_ok
+
     console.print()
     if all_ok:
         console.print("[green]All checks passed![/green]")
     else:
         console.print("[yellow]Some checks failed. Fix the issues above.[/yellow]")
+
+
+def _live_check() -> bool:
+    """Make one minimal API call so a bad key or model fails here, not mid-run."""
+    from noscope.config.settings import load_settings
+    from noscope.errors import explain_error
+    from noscope.llm import create_provider, default_model_for, resolve_provider_name
+    from noscope.llm.base import Message
+
+    try:
+        settings = load_settings()
+    except ValueError as e:
+        console.print(f"  [red]✗[/red] live API check ({e})")
+        return False
+
+    provider_name = resolve_provider_name(settings)
+    model = settings.default_model or default_model_for(provider_name)
+
+    async def _ping() -> str:
+        provider = create_provider(settings)
+        response = await provider.complete(
+            [Message(role="user", content="Reply with the single word: ok")]
+        )
+        return response.content.strip()
+
+    try:
+        reply = asyncio.run(_ping())
+    except Exception as e:  # noqa: BLE001 — surfaced to the user below
+        console.print(f"  [red]✗[/red] live API check ({provider_name}/{model})")
+        hint = explain_error(e, provider=provider_name, model=model)
+        console.print(f"      {hint or f'{type(e).__name__}: {e}'}")
+        return False
+
+    console.print(
+        f"  [green]✓[/green] live API check ({provider_name}/{model}) — replied {reply[:20]!r}"
+    )
+    return True
 
 
 @app.command()

--- a/noscope/cli.py
+++ b/noscope/cli.py
@@ -40,6 +40,7 @@ def run(
     token_budget: int = typer.Option(
         None, "--token-budget", help="Stop the build once this many total tokens are used"
     ),
+    workers: int = typer.Option(None, "--workers", help="Parallel build workers (default 2)"),
 ) -> None:
     """Build an MVP from a spec within a timebox."""
     from noscope.config.settings import load_settings
@@ -56,6 +57,7 @@ def run(
             default_model=model,
             danger_mode=danger,
             token_budget=token_budget,
+            max_workers=workers,
         )
     except ValueError as e:
         console.print(f"[red]Configuration error:[/red] {e}")
@@ -144,6 +146,7 @@ def new(
     token_budget: int = typer.Option(
         None, "--token-budget", help="Stop the build once this many total tokens are used"
     ),
+    workers: int = typer.Option(None, "--workers", help="Parallel build workers (default 2)"),
 ) -> None:
     """Create a new project interactively and start building immediately."""
     from rich.panel import Panel
@@ -217,20 +220,22 @@ def new(
         body=f"# {name.strip()}\n\n{body}",
     )
 
-    # Save spec file for reproducibility
-    spec_filename = name.strip().lower().replace(" ", "-") + ".md"
-    spec_content = f"""---
-name: "{spec.name}"
-timebox: "{spec.timebox}"
-constraints:
-{chr(10).join(f'  - "{c}"' for c in constraints) if constraints else "  []"}
-acceptance:
-{chr(10).join(f'  - "{a.raw}"' for a in acceptance) if acceptance else "  []"}
----
+    # Save spec file for reproducibility. Serialize the frontmatter with a real
+    # YAML dumper — hand-built quoting broke on any name or constraint
+    # containing a quote character.
+    from noscope.spec.parser import build_spec_file, slugify
 
-{spec.body}
-"""
-    Path(spec_filename).write_text(spec_content, encoding="utf-8")
+    spec_filename = slugify(spec.name) + ".md"
+    Path(spec_filename).write_text(
+        build_spec_file(
+            name=spec.name,
+            timebox=spec.timebox,
+            constraints=constraints,
+            acceptance=[a.raw for a in acceptance],
+            body=spec.body,
+        ),
+        encoding="utf-8",
+    )
     console.print(f"\n  [dim]Spec saved to {spec_filename}[/dim]")
 
     # Load settings and run
@@ -243,6 +248,7 @@ acceptance:
             default_model=model,
             danger_mode=danger,
             token_budget=token_budget,
+            max_workers=workers,
         )
     except ValueError as e:
         console.print(f"[red]Configuration error:[/red] {e}")

--- a/noscope/cli.py
+++ b/noscope/cli.py
@@ -131,9 +131,19 @@ def doctor(
     git_ok = shutil.which("git") is not None
     checks.append(("git", git_ok, shutil.which("git") or "not found"))
 
-    # Docker
-    docker_ok = shutil.which("docker") is not None
-    checks.append(("docker (optional)", docker_ok, shutil.which("docker") or "not found"))
+    # Docker — the binary existing says nothing about --sandbox working, so
+    # check the daemon too. This is the exact check `run --sandbox` performs.
+    from noscope.tools.docker import preflight_docker
+
+    docker_problem = asyncio.run(preflight_docker(timeout=5.0))
+    docker_ok = docker_problem is None
+    checks.append(
+        (
+            "docker (optional, for --sandbox)",
+            docker_ok,
+            "daemon reachable" if docker_ok else "unusable — see below",
+        )
+    )
 
     # uv
     uv_ok = shutil.which("uv") is not None
@@ -143,6 +153,10 @@ def doctor(
         icon = "[green]✓[/green]" if ok else "[red]✗[/red]"
         detail_str = f" ({detail})" if detail else ""
         console.print(f"  {icon} {name}{detail_str}")
+
+    if docker_problem:
+        # Optional, so it doesn't fail the run — but say what's actually wrong.
+        console.print(f"\n  [dim]{docker_problem}[/dim]")
 
     all_ok = all(ok for name, ok, _ in checks if "optional" not in name)
 

--- a/noscope/config/settings.py
+++ b/noscope/config/settings.py
@@ -27,6 +27,9 @@ class NoscopeSettings(BaseSettings):
     token_budget: int | None = None
     # Parallel build workers (beyond the setup agents).
     max_workers: int = 2
+    # Longest any single LLM request may run. The SDKs default to 600s and
+    # retry on top of that, which is longer than most timeboxes.
+    request_timeout: float = 120.0
     default_timebox: str = "30m"
     danger_mode: bool = False
 

--- a/noscope/config/settings.py
+++ b/noscope/config/settings.py
@@ -25,6 +25,8 @@ class NoscopeSettings(BaseSettings):
     effort: str = "high"
     # Optional total-token spend cap for a run (a peer to the timebox); None = no cap.
     token_budget: int | None = None
+    # Parallel build workers (beyond the setup agents).
+    max_workers: int = 2
     default_timebox: str = "30m"
     danger_mode: bool = False
 

--- a/noscope/conflicts.py
+++ b/noscope/conflicts.py
@@ -1,0 +1,78 @@
+"""Detect when parallel build agents write over each other.
+
+The planner is told to give each task its own files, but nothing enforces it,
+and a model that ignores the instruction produces the worst kind of failure:
+two workers both "succeed", the last write wins, and the run reports a clean
+build over silently discarded work.
+
+The ledger records who last wrote each file. A different agent overwriting the
+same path with different content is reported back to that agent immediately —
+"re-read this file before you edit it" — and collected for the handoff report,
+so the loss is visible rather than inferred later from missing code.
+
+Writes are warned about, not blocked. Overlap is sometimes legitimate (a worker
+adding a dependency to a manifest the setup agent created), and a harness that
+refuses writes mid-build would fail more runs than it saves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class WriteConflict:
+    """One agent overwrote a file another agent had written."""
+
+    path: str
+    previous_agent: str
+    current_agent: str
+
+    def describe(self) -> str:
+        return (
+            f"{self.path} was written by {self.previous_agent}, "
+            f"then overwritten by {self.current_agent}"
+        )
+
+
+@dataclass
+class WriteLedger:
+    """Tracks the last writer of each workspace path. Shared across agents."""
+
+    _last_writer: dict[str, tuple[str, str]] = field(default_factory=dict)
+    conflicts: list[WriteConflict] = field(default_factory=list)
+
+    def record(self, path: str, agent_id: str, content: str) -> WriteConflict | None:
+        """Record a write. Returns a conflict if it clobbered another agent's."""
+        digest = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+        previous = self._last_writer.get(path)
+        self._last_writer[path] = (agent_id, digest)
+
+        if previous is None:
+            return None
+        previous_agent, previous_digest = previous
+        if previous_agent == agent_id:
+            return None
+        # Rewriting a file to exactly what it already held costs nothing.
+        if previous_digest == digest:
+            return None
+
+        conflict = WriteConflict(path=path, previous_agent=previous_agent, current_agent=agent_id)
+        self.conflicts.append(conflict)
+        return conflict
+
+    def paths_touched_by(self, agent_id: str) -> list[str]:
+        return sorted(p for p, (writer, _) in self._last_writer.items() if writer == agent_id)
+
+    def summary(self) -> str:
+        """A short report line, or empty when the parallel build stayed clean."""
+        if not self.conflicts:
+            return ""
+        # One line per distinct path — repeated clobbers of the same file are
+        # one problem, not several.
+        seen: dict[str, WriteConflict] = {}
+        for c in self.conflicts:
+            seen.setdefault(c.path, c)
+        lines = [f"  - {c.describe()}" for c in seen.values()]
+        return "Parallel agents overwrote each other's files:\n" + "\n".join(lines)

--- a/noscope/context.py
+++ b/noscope/context.py
@@ -1,0 +1,99 @@
+"""Conversation context management.
+
+Agent loops append to a message list every turn and can run for hundreds of
+iterations, with whole-file reads and large command outputs landing in context.
+Left alone that grows until the request fails on context length — and a failed
+request costs the worker its remaining tasks.
+
+Two cheap defenses, both applied before the request is sent:
+
+* ``truncate_tool_output`` caps any single tool result.
+* ``trim_history`` drops the oldest turns once the conversation exceeds a
+  character budget, keeping the system prompt and the original briefing.
+"""
+
+from __future__ import annotations
+
+from noscope.llm.base import Message
+
+# Cap on a single tool result placed into the model's context.
+MAX_TOOL_RESULT_CHARS = 10_000
+
+# Budget for the whole conversation (characters, a cheap proxy for tokens —
+# roughly 4 chars/token, so ~150k chars ≈ 37k tokens).
+MAX_HISTORY_CHARS = 150_000
+
+_ELISION_NOTE = (
+    "[Earlier turns in this conversation were dropped to stay within the "
+    "context limit. The work already done is on disk — read the files you "
+    "need rather than relying on memory of earlier output.]"
+)
+
+
+def truncate_tool_output(text: str, limit: int = MAX_TOOL_RESULT_CHARS) -> str:
+    """Cap a tool result, keeping the head and tail (where errors usually are)."""
+    if len(text) <= limit:
+        return text
+    head = limit // 2
+    tail = limit - head
+    omitted = len(text) - limit
+    return f"{text[:head]}\n... [{omitted:,} characters omitted] ...\n{text[-tail:]}"
+
+
+def _message_size(msg: Message) -> int:
+    size = len(msg.content or "")
+    for tc in msg.tool_calls or []:
+        size += len(tc.name) + len(str(tc.arguments))
+    return size
+
+
+def trim_history(messages: list[Message], max_chars: int = MAX_HISTORY_CHARS) -> list[Message]:
+    """Drop the oldest turns when the conversation exceeds ``max_chars``.
+
+    Always preserved: leading system messages and the first user message (the
+    task briefing). The kept tail never begins with a ``tool`` message, so a
+    tool result is never separated from the assistant turn that requested it —
+    an orphaned tool result is an API error, not just wasted context.
+
+    Returns the original list when it already fits.
+    """
+    if sum(_message_size(m) for m in messages) <= max_chars:
+        return messages
+
+    # Preamble: leading system messages plus the first user message.
+    preamble_end = 0
+    while preamble_end < len(messages) and messages[preamble_end].role == "system":
+        preamble_end += 1
+    if preamble_end < len(messages) and messages[preamble_end].role == "user":
+        preamble_end += 1
+    preamble = messages[:preamble_end]
+    rest = messages[preamble_end:]
+
+    budget = max_chars - sum(_message_size(m) for m in preamble)
+    if budget <= 0:
+        # Even the preamble overflows; keep it and the most recent turn.
+        return preamble + _valid_tail(rest[-1:])
+
+    # Walk backwards keeping as much recent history as fits.
+    kept: list[Message] = []
+    used = 0
+    for msg in reversed(rest):
+        size = _message_size(msg)
+        if used + size > budget:
+            break
+        kept.append(msg)
+        used += size
+    kept.reverse()
+
+    if len(kept) == len(rest):
+        return messages
+
+    return preamble + [Message(role="user", content=_ELISION_NOTE)] + _valid_tail(kept)
+
+
+def _valid_tail(messages: list[Message]) -> list[Message]:
+    """Drop leading ``tool`` messages so no tool result is orphaned."""
+    start = 0
+    while start < len(messages) and messages[start].role == "tool":
+        start += 1
+    return messages[start:]

--- a/noscope/errors.py
+++ b/noscope/errors.py
@@ -1,0 +1,93 @@
+"""Turn provider/SDK exceptions into actionable messages.
+
+A run that dies on a raw ``AuthenticationError`` traceback tells the user
+nothing about what to do next. These helpers map the failures that actually
+happen in practice — bad key, wrong model id, rate limit, network — onto a
+one-line diagnosis plus the fix.
+
+Matching is duck-typed (exception class name + HTTP status) rather than by
+importing provider exception hierarchies, so it works for both the Anthropic
+and OpenAI SDKs and doesn't break when either reorganizes its exports.
+"""
+
+from __future__ import annotations
+
+# Env var to suggest per provider.
+_KEY_HINT = {
+    "anthropic": "NOSCOPE_ANTHROPIC_API_KEY (or ANTHROPIC_API_KEY)",
+    "openai": "NOSCOPE_OPENAI_API_KEY (or OPENAI_API_KEY)",
+}
+
+
+def _status_code(exc: BaseException) -> int | None:
+    code = getattr(exc, "status_code", None)
+    if isinstance(code, int):
+        return code
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
+def explain_error(exc: BaseException, provider: str = "anthropic", model: str = "") -> str | None:
+    """Return an actionable explanation, or None if the error isn't recognized."""
+    name = type(exc).__name__
+    status = _status_code(exc)
+    key_hint = _KEY_HINT.get(provider, "your API key")
+
+    if name == "AuthenticationError" or status == 401:
+        return (
+            f"The {provider} API rejected your credentials.\n"
+            f"  Fix: check {key_hint} is set correctly and not expired.\n"
+            f"  Verify with: uv run noscope doctor --live"
+        )
+
+    if name == "PermissionDeniedError" or status == 403:
+        return (
+            f"The {provider} API key lacks permission for this request"
+            + (f" (model: {model})." if model else ".")
+            + "\n  Fix: confirm the key's workspace has access to that model."
+        )
+
+    if name == "NotFoundError" or status == 404:
+        return (
+            f"The model {model or '(unset)'} was not found on {provider}.\n"
+            "  Fix: pass a current model with --model, e.g.\n"
+            "       --model claude-sonnet-5   (anthropic)\n"
+            "       --model gpt-5.6-terra     (openai)"
+        )
+
+    if name == "RateLimitError" or status == 429:
+        return (
+            "Rate limited by the provider.\n"
+            "  Fix: wait a moment, lower --workers, or use a smaller timebox.\n"
+            "  The SDK already retries automatically; this means retries were exhausted."
+        )
+
+    if status == 529 or "overloaded" in str(exc).lower():
+        return (
+            "The provider is overloaded right now.\n"
+            "  Fix: retry shortly — this is a transient upstream condition."
+        )
+
+    if name in ("APIConnectionError", "APITimeoutError") or status is not None and status >= 500:
+        return (
+            "Could not reach the provider (network or upstream error).\n"
+            "  Fix: check your connection/proxy, then retry."
+        )
+
+    if name == "BadRequestError" or status == 400:
+        return (
+            f"The provider rejected the request as invalid (model: {model or 'default'}).\n"
+            "  This usually means the model doesn't support a parameter NoScope sent.\n"
+            "  Fix: try the default model, or report this with the message below."
+        )
+
+    return None
+
+
+def format_run_error(exc: BaseException, provider: str = "anthropic", model: str = "") -> str:
+    """A user-facing block for a run-ending error: diagnosis when we have one."""
+    explanation = explain_error(exc, provider=provider, model=model)
+    if explanation:
+        return f"{explanation}\n\n  Details: {type(exc).__name__}: {exc}"
+    return f"{type(exc).__name__}: {exc}"

--- a/noscope/errors.py
+++ b/noscope/errors.py
@@ -41,6 +41,13 @@ def explain_error(exc: BaseException, provider: str = "anthropic", model: str = 
             f"  Verify with: uv run noscope doctor --live"
         )
 
+    if name == "RequestTimeoutError":
+        return (
+            "A model request was abandoned so it couldn't outrun the timebox.\n"
+            "  Fix: raise NOSCOPE_REQUEST_TIMEOUT (default 120s) if your model\n"
+            "       legitimately needs longer, or use a larger --time."
+        )
+
     if name == "PermissionDeniedError" or status == 403:
         return (
             f"The {provider} API key lacks permission for this request"

--- a/noscope/llm/bounded.py
+++ b/noscope/llm/bounded.py
@@ -1,0 +1,89 @@
+"""Wrap a provider so no single request can outlive the timebox.
+
+NoScope's headline promise is a hard deadline, but the deadline is
+*cooperative* — agents check it between iterations, so it cannot interrupt a
+request already in flight. Both SDKs default to a 600-second read timeout and
+retry on top of that, which means one stalled call could block for tens of
+minutes and blow a five-minute timebox entirely.
+
+This wrapper closes that gap at the one place every call passes through.
+Because ``asyncio.wait_for`` wraps the whole SDK call, the bound covers the
+SDK's internal retries too, not just a single attempt.
+
+A floor is deliberate: HANDOFF runs *after* the deadline by design ("always
+produce output"), so a request is never given zero time — past the deadline it
+still gets ``MIN_REQUEST_TIMEOUT`` to produce the report.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from noscope.deadline import Deadline
+from noscope.llm.base import LLMProvider, LLMResponse, Message, ToolSchema
+
+# Longest any single request may run, however much timebox is left. Generous
+# enough for a long structured plan, short enough that a stall is survivable.
+DEFAULT_REQUEST_TIMEOUT = 120.0
+
+# Never give a request less than this, even past the deadline — HANDOFF still
+# has to be able to write its report.
+MIN_REQUEST_TIMEOUT = 30.0
+
+
+class RequestTimeoutError(Exception):
+    """A single LLM request exceeded its share of the timebox."""
+
+
+class DeadlineBoundProvider:
+    """Delegates to a real provider, capping how long any one call may take."""
+
+    def __init__(
+        self,
+        inner: LLMProvider,
+        deadline: Deadline,
+        max_seconds: float = DEFAULT_REQUEST_TIMEOUT,
+    ) -> None:
+        self._inner = inner
+        self._deadline = deadline
+        self._max_seconds = max_seconds
+
+    def timeout_for_now(self) -> float:
+        """Seconds to allow the next request.
+
+        The floor applies to the *remaining timebox*, not to the configured
+        cap: an expired deadline must not starve HANDOFF, but an explicitly
+        configured ``max_seconds`` is a deliberate choice and always wins.
+        """
+        return min(self._max_seconds, max(MIN_REQUEST_TIMEOUT, self._deadline.remaining()))
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        model: str | None = None,
+        json_schema: dict[str, Any] | None = None,
+        effort: str | None = None,
+    ) -> LLMResponse:
+        timeout = self.timeout_for_now()
+        try:
+            return await asyncio.wait_for(
+                self._inner.complete(
+                    messages,
+                    tools=tools,
+                    model=model,
+                    json_schema=json_schema,
+                    effort=effort,
+                ),
+                timeout=timeout,
+            )
+        except TimeoutError as e:
+            raise RequestTimeoutError(
+                f"The model did not respond within {timeout:.0f}s. "
+                "The request was abandoned so the run keeps its timebox."
+            ) from e
+
+    def __getattr__(self, name: str) -> Any:
+        # Anything else (provider-specific attributes, test hooks) passes through.
+        return getattr(self._inner, name)

--- a/noscope/llm/dryrun.py
+++ b/noscope/llm/dryrun.py
@@ -1,0 +1,131 @@
+"""A no-cost provider that exercises the full pipeline without an API key.
+
+``noscope run --dry-run`` swaps this in for a real provider. Every phase runs
+for real — the workspace is created, tools execute, acceptance checks and the
+verification command actually run in the shell, the event log and handoff
+report are written — but no network call is made and no tokens are spent.
+
+It's a smoke test for the harness itself: if a dry run completes, the CLI,
+capability gating, tool dispatch, phase budgets, and reporting all work, and
+anything that fails on a live run is about the model or the API, not the
+plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from noscope.llm.base import LLMResponse, Message, ToolCall, ToolSchema, Usage
+
+# The artifact a dry run "builds" — deliberately trivial and dependency-free.
+DRY_RUN_FILE = "index.html"
+_DRY_RUN_HTML = (
+    "<!doctype html>\n"
+    "<html><head><title>NoScope dry run</title></head>\n"
+    "<body><h1>NoScope dry run</h1>\n"
+    "<p>This file was produced without calling any model.</p></body></html>\n"
+)
+
+_PLAN = {
+    "requested_capabilities": [
+        {"cap": "workspace_rw", "why": "write the artifact", "risk": "low"},
+        {"cap": "shell_exec", "why": "run acceptance checks", "risk": "medium"},
+    ],
+    "tasks": [
+        {
+            "id": "t1",
+            "title": "Set up project structure and install dependencies",
+            "kind": "edit",
+            "priority": "mvp",
+            "description": f"Create {DRY_RUN_FILE}",
+            "depends_on": [],
+        }
+    ],
+    "mvp_definition": [f"{DRY_RUN_FILE} exists"],
+    "exclusions": ["Anything requiring a real model"],
+    "acceptance_plan": [
+        {"name": "artifact exists", "cmd": f"test -f {DRY_RUN_FILE}", "must_pass": True}
+    ],
+}
+
+
+class DryRunProvider:
+    """Scripted provider: enough behavior to drive every phase to completion."""
+
+    def __init__(self) -> None:
+        self._wrote = False
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        model: str | None = None,
+        json_schema: dict[str, Any] | None = None,
+        effort: str | None = None,
+    ) -> LLMResponse:
+        system = messages[0].content if messages else ""
+        names = {t.name for t in (tools or [])}
+        usage = Usage(input_tokens=0, output_tokens=0)
+
+        # PLAN — the only structured-output call in the pipeline.
+        if json_schema is not None:
+            return LLMResponse(content=json.dumps(_PLAN), usage=usage)
+
+        # VERIFY — propose a proof command the harness will really execute.
+        if "confirm_running" in names:
+            return LLMResponse(
+                tool_calls=[
+                    ToolCall(
+                        id="dry-verify",
+                        name="confirm_running",
+                        arguments={
+                            "command": f"test -f {DRY_RUN_FILE}",
+                            "summary": f"{DRY_RUN_FILE} was created (dry run — no model used)",
+                        },
+                    )
+                ],
+                usage=usage,
+            )
+
+        # BUILD — the structure agent writes the artifact, then marks the task.
+        if "mark_task_complete" in names:
+            if "DEPS agent" in system:
+                return LLMResponse(
+                    content="No dependencies to install.", stop_reason="end_turn", usage=usage
+                )
+            if not self._wrote:
+                self._wrote = True
+                return LLMResponse(
+                    tool_calls=[
+                        ToolCall(
+                            id="dry-write",
+                            name="write_file",
+                            arguments={"path": DRY_RUN_FILE, "content": _DRY_RUN_HTML},
+                        )
+                    ],
+                    usage=usage,
+                )
+            return LLMResponse(
+                tool_calls=[
+                    ToolCall(id="dry-done", name="mark_task_complete", arguments={"task_id": "t1"})
+                ],
+                usage=usage,
+            )
+
+        # HARDEN repair (shouldn't be needed) and HANDOFF land here.
+        return LLMResponse(
+            content=(
+                "# Handoff Report (dry run)\n\n"
+                "This run used `--dry-run`, so no model was called and no tokens "
+                "were spent.\n\n"
+                "## What Was Built\n\n"
+                f"- `{DRY_RUN_FILE}` — a placeholder artifact\n\n"
+                "## How to Run It\n\n"
+                f"Open `{DRY_RUN_FILE}` in a browser.\n\n"
+                "## Next Steps\n\n"
+                "Re-run without `--dry-run` (and with an API key) to build for real.\n"
+            ),
+            stop_reason="end_turn",
+            usage=usage,
+        )

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 from typing import Any
@@ -477,7 +478,10 @@ def _detect_launch(workspace: Path) -> tuple[str | None, str]:
 async def _run_server(command: str, workspace: Path) -> None:
     """Start the server and let the user interact with it. Blocks until Ctrl+C."""
     import asyncio
+    import os
     import signal
+
+    from noscope.tools.shell import kill_process_group
 
     env = build_execution_env()
 
@@ -487,6 +491,10 @@ async def _run_server(command: str, workspace: Path) -> None:
         env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        # Its own session, so Ctrl+C takes down the whole server tree rather
+        # than just the shell — otherwise the dev server survives and the port
+        # stays bound.
+        start_new_session=True,
     )
 
     try:
@@ -497,11 +505,13 @@ async def _run_server(command: str, workspace: Path) -> None:
                 break
             print(line.decode("utf-8", errors="replace"), end="")
     except (KeyboardInterrupt, asyncio.CancelledError):
-        proc.send_signal(signal.SIGTERM)
+        # Ask the tree to stop politely first; servers flush and close ports.
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
         try:
             await asyncio.wait_for(proc.wait(), timeout=5)
         except TimeoutError:
-            proc.kill()
+            await kill_process_group(proc)
 
 
 def _workspace_has_files(workspace: Path) -> bool:

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from noscope.capabilities import CapabilityStore
 from noscope.config.settings import NoscopeSettings
 from noscope.deadline import Deadline, Phase
+from noscope.errors import format_run_error
 from noscope.llm import create_provider, default_model_for, resolve_provider_name
 from noscope.logging.events import EventLog, RunDir
 from noscope.phases import (
@@ -58,16 +59,29 @@ from noscope.ui.console import ConsoleUI
 class Orchestrator:
     """Orchestrates the full NoScope run lifecycle."""
 
-    def __init__(self, settings: NoscopeSettings, console: Console | None = None) -> None:
+    def __init__(
+        self,
+        settings: NoscopeSettings,
+        console: Console | None = None,
+        dry_run: bool = False,
+    ) -> None:
         self.settings = settings
-        self.provider = create_provider(settings)
+        self.dry_run = dry_run
+        if dry_run:
+            from noscope.llm.dryrun import DryRunProvider
+
+            self.provider: Any = DryRunProvider()
+        else:
+            self.provider = create_provider(settings)
         self.ui = ConsoleUI(console)
         self._provider_name = resolve_provider_name(settings)
         self._model = settings.default_model or default_model_for(self._provider_name)
         # fast_model is an Anthropic model id; only apply it on the Anthropic
         # provider, and never override an explicit --model.
         self._report_model = (
-            settings.fast_model
+            None
+            if dry_run
+            else settings.fast_model
             if self._provider_name == "anthropic" and settings.default_model is None
             else None
         )
@@ -318,7 +332,12 @@ class Orchestrator:
                 summary=f"Run error: {e}",
                 data={"error": str(e), "type": type(e).__name__},
             )
-            self.ui.console.print(f"\n[red]Error:[/red] {e}")
+            # Explain the failure in terms the user can act on (bad key, wrong
+            # model, rate limit, ...) instead of leaving a bare exception.
+            self.ui.console.print(
+                f"\n[red]Run failed:[/red] "
+                f"{format_run_error(e, provider=self._provider_name, model=self._model)}"
+            )
             if not tasks and plan_output is not None:
                 tasks = plan_output.tasks
 

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -268,6 +268,7 @@ class Orchestrator:
                 deadline=deadline,
                 ui=self.ui,
                 tokens=tokens,
+                max_workers=self.settings.max_workers,
             )
             tasks = await supervisor.run(plan_output, workspace)
             completed = sum(1 for t in tasks if t.completed)

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -37,6 +37,7 @@ from noscope.tools.docker import (
     DockerSandbox,
     DockerShellTool,
     DockerWriteFileTool,
+    preflight_docker,
 )
 from noscope.tools.filesystem import (
     CreateDirectoryTool,
@@ -179,6 +180,18 @@ class Orchestrator:
         dispatcher = ToolDispatcher()
 
         if sandbox:
+            # Fail here, before PLAN — a sandbox that dies mid-build has already
+            # burned tokens and timebox for nothing.
+            problem = await preflight_docker()
+            if problem:
+                self.ui.console.print(f"\n[red]Sandbox unavailable[/red]\n  {problem}\n")
+                event_log.emit(
+                    phase="INIT",
+                    event_type="run.aborted",
+                    summary="Docker sandbox unavailable",
+                    data={"reason": problem},
+                )
+                return run_dir.path
             docker_sandbox = DockerSandbox(workspace)
             await docker_sandbox.ensure_running()
             self.ui.console.print(

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from noscope.capabilities import CapabilityStore
 from noscope.config.settings import NoscopeSettings
+from noscope.conflicts import WriteLedger
 from noscope.deadline import Deadline, Phase
 from noscope.errors import format_run_error
 from noscope.llm import create_provider, default_model_for, resolve_provider_name
@@ -234,6 +235,9 @@ class Orchestrator:
         acceptance_results: list[dict[str, Any]] = []
         plan_output: PlanOutput | None = None
         verify_data: tuple[bool, str] | None = None
+        # Declared out here because HANDOFF reads it even when an earlier
+        # phase raised before BUILD ever created the agents.
+        write_ledger = WriteLedger()
 
         try:
             # 5. PLAN phase
@@ -279,6 +283,8 @@ class Orchestrator:
 
             # 8. BUILD phase
             self.ui.phase_banner(Phase.BUILD, "Building MVP...", deadline.format_remaining())
+            # The ledger is shared across every agent; each agent gets a context
+            # copy carrying its own id, so overlapping writes are attributable.
             tool_context = ToolContext(
                 workspace=workspace,
                 capabilities=cap_store,
@@ -286,6 +292,7 @@ class Orchestrator:
                 deadline=deadline,
                 secrets=_runtime_secrets(self.settings),
                 danger_mode=self.settings.danger_mode,
+                write_ledger=write_ledger,
             )
 
             supervisor = Supervisor(
@@ -301,6 +308,11 @@ class Orchestrator:
             tasks = await supervisor.run(plan_output, workspace)
             completed = sum(1 for t in tasks if t.completed)
             self.ui.console.print(f"  Completed [cyan]{completed}/{len(tasks)}[/cyan] tasks")
+
+            if write_ledger.conflicts:
+                # Say it out loud. Silently losing a worker's output while
+                # reporting a clean build is the worst outcome available.
+                self.ui.console.print(f"  [yellow]{write_ledger.summary()}[/yellow]")
 
             # 9. HARDEN phase
             self.ui.phase_banner(
@@ -372,6 +384,7 @@ class Orchestrator:
                 workspace=workspace,
                 verify_result=verify_data,
                 report_model=self._report_model,
+                write_conflicts=write_ledger.summary(),
             )
         except Exception as e:
             event_log.emit(

--- a/noscope/orchestrator.py
+++ b/noscope/orchestrator.py
@@ -15,6 +15,7 @@ from noscope.conflicts import WriteLedger
 from noscope.deadline import Deadline, Phase
 from noscope.errors import format_run_error
 from noscope.llm import create_provider, default_model_for, resolve_provider_name
+from noscope.llm.bounded import DeadlineBoundProvider
 from noscope.logging.events import EventLog, RunDir
 from noscope.phases import (
     HandoffPhase,
@@ -175,6 +176,15 @@ class Orchestrator:
 
         # 4. Start deadline
         deadline = Deadline(spec.timebox_seconds)
+
+        # The deadline is cooperative — agents check it between iterations, so
+        # it cannot interrupt a request already in flight. Bounding each call
+        # here is what makes the timebox a real guarantee rather than a best
+        # effort; without it one stalled request (600s SDK default, times
+        # retries) could outlast the whole run.
+        self.provider = DeadlineBoundProvider(
+            self.provider, deadline, max_seconds=self.settings.request_timeout
+        )
 
         # Set up tools — route ALL operations through Docker when sandbox is active
         docker_sandbox: DockerSandbox | None = None

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -573,6 +573,7 @@ class HandoffPhase:
         workspace: Path | None = None,
         verify_result: tuple[bool, str] | None = None,
         report_model: str | None = None,
+        write_conflicts: str = "",
     ) -> str:
         event_log.emit(
             phase=Phase.HANDOFF.value,
@@ -677,6 +678,16 @@ Write the report with these sections:
                 summary=f"LLM handoff report failed, using fallback: {e}",
             )
             report = self._fallback_report(spec, completed, incomplete, acceptance_results)
+
+        if write_conflicts:
+            # Appended rather than prompted, so the model can't leave it out.
+            # Overwritten work is exactly the kind of gap a handoff must name.
+            report = (
+                f"{report.rstrip()}\n\n## Parallel Write Conflicts\n\n"
+                f"{write_conflicts}\n\n"
+                "Check these files — a later agent may have discarded an "
+                "earlier one's work.\n"
+            )
 
         output_path.write_text(report, encoding="utf-8")
 

--- a/noscope/phases.py
+++ b/noscope/phases.py
@@ -10,6 +10,7 @@ from noscope.capabilities import (
     CapabilityGrant,
     CapabilityRequest,
 )
+from noscope.context import trim_history, truncate_tool_output
 from noscope.deadline import Deadline, Phase
 from noscope.llm.base import LLMProvider, Message, ToolSchema, Usage
 from noscope.logging.events import EventLog
@@ -309,6 +310,7 @@ the harness re-runs it after you finish.
                 return
             if tokens is not None and tokens.exceeded():
                 return
+            messages = trim_history(messages)
             response = await provider.complete(messages, tools=tool_schemas, effort="medium")
             if tokens:
                 tokens.add(response.usage)
@@ -322,7 +324,7 @@ the harness re-runs it after you finish.
                 messages.append(
                     Message(
                         role="tool",
-                        content=result.display or json.dumps(result.data),
+                        content=truncate_tool_output(result.display or json.dumps(result.data)),
                         tool_call_id=tc.id,
                     )
                 )
@@ -410,6 +412,7 @@ the blocker instead of looping.
             if tokens is not None and tokens.exceeded():
                 return self._fail(event_log, "Token budget reached during verification")
 
+            messages = trim_history(messages)
             response = await provider.complete(messages, tools=tool_schemas)
             if tokens:
                 tokens.add(response.usage)
@@ -449,7 +452,7 @@ the blocker instead of looping.
                 messages.append(
                     Message(
                         role="tool",
-                        content=result.display or json.dumps(result.data),
+                        content=truncate_tool_output(result.display or json.dumps(result.data)),
                         tool_call_id=tc.id,
                     )
                 )

--- a/noscope/spec/parser.py
+++ b/noscope/spec/parser.py
@@ -1,12 +1,42 @@
-"""Markdown + YAML frontmatter spec parser."""
+"""Markdown + YAML frontmatter spec parsing and generation."""
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import frontmatter
+import yaml
 
 from noscope.spec.models import AcceptanceCheck, SpecInput
+
+
+def slugify(name: str) -> str:
+    """Turn a project name into a safe single-segment filename stem."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return slug or "spec"
+
+
+def build_spec_file(
+    name: str,
+    timebox: str,
+    constraints: list[str],
+    acceptance: list[str],
+    body: str,
+) -> str:
+    """Render a spec file with correctly escaped YAML frontmatter.
+
+    Uses a real YAML dumper so names or constraints containing quotes,
+    colons, or newlines produce a valid file.
+    """
+    meta = {
+        "name": name,
+        "timebox": timebox,
+        "constraints": constraints,
+        "acceptance": acceptance,
+    }
+    front = yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, default_flow_style=False)
+    return f"---\n{front}---\n\n{body}\n"
 
 
 def parse_spec(path: Path) -> SpecInput:

--- a/noscope/supervisor.py
+++ b/noscope/supervisor.py
@@ -19,8 +19,9 @@ if TYPE_CHECKING:
     from noscope.phases import TokenTracker
     from noscope.ui.console import ConsoleUI
 
-# Maximum parallel workers (beyond setup agent).
-# Keep at 2 to avoid API rate limits with concurrent LLM streams.
+# Default maximum parallel workers (beyond the setup agents). Conservative by
+# default to stay under provider rate limits with concurrent LLM streams;
+# override per run with --workers / NOSCOPE_MAX_WORKERS.
 MAX_WORKERS = 2
 
 
@@ -42,7 +43,9 @@ class Supervisor:
         deadline: Deadline,
         ui: ConsoleUI | None = None,
         tokens: TokenTracker | None = None,
+        max_workers: int = MAX_WORKERS,
     ) -> None:
+        self.max_workers = max(1, max_workers)
         self.provider = provider
         self.dispatcher = dispatcher
         self.context = context
@@ -283,7 +286,7 @@ class Supervisor:
         streams = [self._topo_sort(chain) for chain in components.values()]
 
         # Merge the smallest streams until we're within the worker limit
-        while len(streams) > MAX_WORKERS:
+        while len(streams) > self.max_workers:
             streams.sort(key=len)
             smallest = streams.pop(0)
             merged = sorted(smallest + streams[0], key=lambda t: order[t.id])

--- a/noscope/supervisor.py
+++ b/noscope/supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -185,28 +186,36 @@ class Supervisor:
                 ui=self.ui,
                 feed=feed,
             )
-            audit_coro = audit.run_continuous()
+            # The auditor loops until BUILD is nearly over, so it must not be
+            # gathered alongside the workers — that made a build which finished
+            # early sit idle for the rest of BUILD's budget before HARDEN could
+            # start, spending the timebox this tool exists to protect.
+            audit_task = asyncio.ensure_future(audit.run_continuous())
 
-            # Run workers and audit concurrently
             gather_results: list[object] = list(
-                await asyncio.gather(*worker_coros, audit_coro, return_exceptions=True)
+                await asyncio.gather(*worker_coros, return_exceptions=True)
             )
+
+            # Workers are done; stop auditing. Findings already published are
+            # kept — the feed accumulates them, so cancelling loses nothing.
+            audit_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await audit_task
+            audit_findings = list(feed.all_findings)
 
             # Log any worker exceptions (don't let failures go silent)
             for i, result in enumerate(gather_results):  # type: ignore[assignment]
                 if isinstance(result, BaseException):
-                    label = f"worker-{i}" if i < len(worker_coros) else "audit"
                     self.event_log.emit(
                         phase=Phase.BUILD.value,
                         event_type="agent.error",
-                        summary=f"Agent {label} failed: {result}",
-                        data={"agent": label, "error": str(result), "type": type(result).__name__},
+                        summary=f"Agent worker-{i} failed: {result}",
+                        data={
+                            "agent": f"worker-{i}",
+                            "error": str(result),
+                            "type": type(result).__name__,
+                        },
                     )
-
-            # The final gather slot is the audit agent's findings
-            last_result = gather_results[-1] if gather_results else None
-            if isinstance(last_result, list):
-                audit_findings = last_result
 
         # Summary
         completed = sum(1 for t in all_tasks if t.completed)

--- a/noscope/tools/base.py
+++ b/noscope/tools/base.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from noscope.capabilities import Capability, CapabilityStore
+from noscope.conflicts import WriteLedger
 from noscope.deadline import Deadline
 from noscope.logging.events import EventLog
 
@@ -22,6 +23,10 @@ class ToolContext:
     deadline: Deadline
     secrets: dict[str, str] = field(default_factory=dict)
     danger_mode: bool = False
+    # Who is acting. Build agents each get a copy of the context carrying their
+    # own id, so writes can be attributed. The ledger itself stays shared.
+    agent_id: str = "main"
+    write_ledger: WriteLedger | None = None
 
 
 @dataclass
@@ -81,3 +86,33 @@ def tool_summary(name: str, args: dict[str, Any]) -> str:
     if name in ("git_init", "git_status", "git_add", "git_commit", "git_diff"):
         return name.replace("_", " ")
     return name
+
+
+def record_write(context: ToolContext, rel_path: str, content: str) -> str:
+    """Record a file write and return a warning to append to the tool output.
+
+    Returns "" in the common case. When another agent wrote the same file
+    first, the warning goes straight back into the writing agent's context so
+    it can re-read before continuing, and the conflict is logged for the report.
+    """
+    if context.write_ledger is None:
+        return ""
+    conflict = context.write_ledger.record(rel_path, context.agent_id, content)
+    if conflict is None:
+        return ""
+
+    context.event_log.emit(
+        phase=context.deadline.current_phase.value,
+        event_type="write.conflict",
+        summary=conflict.describe(),
+        data={
+            "path": conflict.path,
+            "previous_agent": conflict.previous_agent,
+            "current_agent": conflict.current_agent,
+        },
+    )
+    return (
+        f"\n[warning] {conflict.previous_agent} also wrote {rel_path}. You may have "
+        "discarded their work — read the file back before making further edits, "
+        "and prefer edit_file over write_file on shared files."
+    )

--- a/noscope/tools/docker.py
+++ b/noscope/tools/docker.py
@@ -11,6 +11,7 @@ import asyncio
 import base64
 import posixpath
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +63,54 @@ def build_write_command(rel_path: str, content: str) -> str:
     parent = posixpath.dirname(path)
     mkdir = f"mkdir -p '/workspace/{parent}' && " if parent else ""
     return f"{mkdir}printf %s '{b64}' | base64 -d > '/workspace/{path}'"
+
+
+async def preflight_docker(timeout: float = 15.0) -> str | None:
+    """Check that ``--sandbox`` can actually work. Returns an error, or None.
+
+    Run this *before* the first model call. A sandbox that only fails once the
+    build is underway wastes the timebox and the tokens already spent, and the
+    raw daemon error ("Cannot connect to the Docker daemon at
+    unix:///var/run/docker.sock") doesn't tell the user what to do.
+    """
+    if shutil.which("docker") is None:
+        return (
+            "--sandbox needs Docker, but the `docker` command was not found.\n"
+            "  Fix: install Docker Desktop or the Docker Engine, or drop --sandbox\n"
+            "       to run on the host (commands are still safety-filtered)."
+        )
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "info",
+            "--format",
+            "{{.ServerVersion}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        await kill_process_group(proc)
+        return (
+            f"The Docker daemon did not respond within {timeout:.0f}s.\n"
+            "  Fix: check that Docker is running, then retry."
+        )
+    except OSError as e:
+        return f"Could not run docker: {e}"
+
+    if proc.returncode != 0:
+        detail = stderr.decode("utf-8", errors="replace").strip().splitlines()
+        first = detail[0] if detail else "unknown error"
+        return (
+            "The `docker` command exists but the daemon is not reachable.\n"
+            "  Fix: start Docker (Docker Desktop, or `sudo systemctl start docker`),\n"
+            "       or drop --sandbox to run on the host.\n"
+            f"  Daemon said: {first}"
+        )
+
+    return None
 
 
 class DockerSandbox:

--- a/noscope/tools/docker.py
+++ b/noscope/tools/docker.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from noscope.capabilities import Capability
-from noscope.tools.base import Tool, ToolContext, ToolResult
+from noscope.tools.base import Tool, ToolContext, ToolResult, record_write
 from noscope.tools.redaction import redact_text
 from noscope.tools.safety import check_command_safety
 from noscope.tools.shell import kill_process_group
@@ -364,7 +364,8 @@ class DockerWriteFileTool(Tool):
         ok, err = await self._docker._write_in_container(args["path"], args["content"])
         if not ok:
             return ToolResult.error(f"Failed to write: {err}")
-        return ToolResult.ok(display=f"Wrote {args['path']}", path=args["path"])
+        warning = record_write(context, args["path"], args["content"])
+        return ToolResult.ok(display=f"Wrote {args['path']}{warning}", path=args["path"])
 
 
 class DockerListDirectoryTool(Tool):

--- a/noscope/tools/docker.py
+++ b/noscope/tools/docker.py
@@ -411,7 +411,11 @@ class DockerShellTool(Tool):
 
     async def execute(self, args: dict[str, Any], context: ToolContext) -> ToolResult:
         command = args["command"]
-        timeout = min(args.get("timeout", 60), 300)
+        # Match the host shell tool: never let one container command run past a
+        # meaningful share of the remaining timebox.
+        remaining = context.deadline.remaining()
+        dynamic_cap = max(30, int(remaining * 0.15))
+        timeout = min(args.get("timeout", 60), 300, dynamic_cap)
         cwd = args.get("cwd", "/workspace")
 
         # Safety filters still apply unless --danger is set

--- a/noscope/tools/docker.py
+++ b/noscope/tools/docker.py
@@ -18,6 +18,7 @@ from noscope.capabilities import Capability
 from noscope.tools.base import Tool, ToolContext, ToolResult
 from noscope.tools.redaction import redact_text
 from noscope.tools.safety import check_command_safety
+from noscope.tools.shell import kill_process_group
 
 DOCKER_IMAGE = "python:3.12-slim"
 DOCKER_MEMORY_LIMIT = "1g"
@@ -151,10 +152,14 @@ class DockerSandbox:
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except TimeoutError:
+            # Reap the `docker exec` client; otherwise it lingers attached to
+            # the container, holding its pipes, for the rest of the run.
+            await kill_process_group(proc)
             return 124, "", f"Command timed out after {timeout}s"
 
         return (

--- a/noscope/tools/filesystem.py
+++ b/noscope/tools/filesystem.py
@@ -6,7 +6,7 @@ import difflib
 from typing import Any
 
 from noscope.capabilities import Capability
-from noscope.tools.base import Tool, ToolContext, ToolResult
+from noscope.tools.base import Tool, ToolContext, ToolResult, record_write
 from noscope.tools.safety import resolve_workspace_path
 
 
@@ -85,7 +85,8 @@ class WriteFileTool(Tool):
         path = resolve_workspace_path(args["path"], context.workspace)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(args["content"], encoding="utf-8")
-        return ToolResult.ok(display=f"Wrote {path}", path=str(path))
+        warning = record_write(context, args["path"], args["content"])
+        return ToolResult.ok(display=f"Wrote {path}{warning}", path=str(path))
 
 
 class EditFileTool(Tool):
@@ -154,11 +155,12 @@ class EditFileTool(Tool):
 
         updated = original.replace(old_string, new_string)
         path.write_text(updated, encoding="utf-8")
+        warning = record_write(context, args["path"], updated)
 
         diff = _unified_diff(original, updated, args["path"])
         replaced = count if replace_all else 1
         return ToolResult.ok(
-            display=f"Edited {args['path']} ({replaced} replacement(s))\n{diff}",
+            display=f"Edited {args['path']} ({replaced} replacement(s)){warning}\n{diff}",
             path=str(path),
             replacements=replaced,
         )

--- a/noscope/tools/shell.py
+++ b/noscope/tools/shell.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import signal
 from collections.abc import Mapping
+from contextlib import suppress
 from typing import Any
 
 from noscope.capabilities import Capability
@@ -38,6 +40,8 @@ _SENSITIVE_ENV_KEY_PATTERN = re.compile(
 )
 
 MAX_OUTPUT_LENGTH = 50_000
+# How long to wait for a killed process tree to actually go away.
+KILL_GRACE_SECONDS = 5.0
 
 
 def build_execution_env(base_env: Mapping[str, str] | None = None) -> dict[str, str]:
@@ -57,6 +61,25 @@ def build_execution_env(base_env: Mapping[str, str] | None = None) -> dict[str, 
         cleaned = [p for p in path_parts if ".venv" not in p]
         env["PATH"] = os.pathsep.join(cleaned)
     return env
+
+
+async def kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """Terminate a timed-out command and everything it spawned, then reap it.
+
+    Killing only the shell is not enough. ``sh -c "npm run dev"`` leaves the
+    server running as an orphan, still holding the stdout pipe — so the run
+    never gets its file descriptors back and ``proc.wait()`` blocks until the
+    orphan happens to exit. Because the child was started in its own session,
+    one ``killpg`` takes down the whole tree.
+    """
+    with suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    with suppress(ProcessLookupError, OSError):
+        await asyncio.wait_for(proc.wait(), timeout=KILL_GRACE_SECONDS)
+    if proc.returncode is None:  # pragma: no cover — killpg already covers this
+        with suppress(ProcessLookupError, OSError):
+            proc.kill()
+            await proc.wait()
 
 
 class ShellTool(Tool):
@@ -113,10 +136,13 @@ class ShellTool(Tool):
                 env=build_execution_env(),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                # Own process group, so a timeout can take the whole tree down
+                # (see kill_process_group).
+                start_new_session=True,
             )
             stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except TimeoutError:
-            proc.kill()
+            await kill_process_group(proc)
             return ToolResult.error(f"Command timed out after {timeout}s")
         except OSError as e:
             return ToolResult.error(f"Failed to execute: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Repository = "https://github.com/ideksec/NoScope"
 Issues = "https://github.com/ideksec/NoScope/issues"
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "ruff", "mypy", "pytest-cov"]
+dev = ["pytest", "pytest-asyncio", "ruff", "mypy", "pytest-cov", "types-PyYAML"]
 
 [project.scripts]
 noscope = "noscope.cli:main"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -113,9 +113,16 @@ class TestBuildAgent:
         event_log.close()
 
 
+def _supervisor(max_workers: int = 2) -> Supervisor:
+    """A Supervisor with just the fields the pure planning helpers need."""
+    sup = Supervisor.__new__(Supervisor)
+    sup.max_workers = max_workers
+    return sup
+
+
 class TestSupervisor:
     def test_split_setup(self) -> None:
-        supervisor = Supervisor.__new__(Supervisor)
+        supervisor = _supervisor()
         tasks = _make_tasks()
         setup, remaining = supervisor._split_setup(tasks)
         assert len(setup) == 1
@@ -123,7 +130,7 @@ class TestSupervisor:
         assert len(remaining) == 3
 
     def test_partition_tasks(self) -> None:
-        supervisor = Supervisor.__new__(Supervisor)
+        supervisor = _supervisor()
         tasks = [
             PlanTask(id="t2", title="Feature A", kind="edit", depends_on=["t1"]),
             PlanTask(id="t3", title="Feature B", kind="edit", depends_on=["t1"]),
@@ -138,13 +145,13 @@ class TestSupervisor:
         assert all_ids == {"t2", "t3", "t4"}
 
     def test_partition_empty(self) -> None:
-        supervisor = Supervisor.__new__(Supervisor)
+        supervisor = _supervisor()
         assert supervisor._partition_tasks([]) == []
 
     def test_partition_groups_transitive_chains(self) -> None:
         # t4 -> t3 -> t2 is a transitive chain: all three must share a stream
         # even though t4 never directly names t2 (issue #3)
-        supervisor = Supervisor.__new__(Supervisor)
+        supervisor = _supervisor()
         tasks = [
             PlanTask(id="t2", title="Models", kind="edit", depends_on=["t1"]),
             PlanTask(id="t3", title="API", kind="edit", depends_on=["t2"]),
@@ -162,12 +169,9 @@ class TestSupervisor:
         assert any(t.id == "t5" for s in streams for t in s if s is not chain_stream)
 
     def test_partition_respects_max_workers(self) -> None:
-        from noscope.supervisor import MAX_WORKERS
-
-        supervisor = Supervisor.__new__(Supervisor)
         tasks = [PlanTask(id=f"t{i}", title=f"Task {i}", kind="edit") for i in range(2, 10)]
-        streams = supervisor._partition_tasks(tasks)
-        assert len(streams) <= MAX_WORKERS
+        streams = _supervisor()._partition_tasks(tasks)
+        assert len(streams) <= 2
         all_ids = {t.id for s in streams for t in s}
         assert all_ids == {t.id for t in tasks}
 
@@ -181,7 +185,7 @@ class TestSupervisor:
         assert [t.id for t in result] == ["t2", "t3"]
 
     def test_split_setup_with_no_setup_keyword(self) -> None:
-        supervisor = Supervisor.__new__(Supervisor)
+        supervisor = _supervisor()
         tasks = [
             PlanTask(id="t1", title="Create API routes", kind="edit"),
             PlanTask(id="t2", title="Add database", kind="edit"),
@@ -342,3 +346,43 @@ class TestTokenBudget:
         await agent.run([PlanTask(id="t1", title="Build", kind="edit")], "Build it.")
         event_log.close()
         assert calls["n"] == 1  # stopped after the first over-budget call
+
+
+class TestAuditSyntaxChecks:
+    @pytest.mark.asyncio
+    async def test_detects_python_syntax_error(self, tool_context: ToolContext) -> None:
+        from noscope.tools.dispatcher import ToolDispatcher
+        from noscope.tools.shell import ShellTool
+
+        (tool_context.workspace / "requirements.txt").write_text("flask\n")
+        (tool_context.workspace / "app.py").write_text("def broken(:\n")
+
+        dispatcher = ToolDispatcher()
+        dispatcher.register(ShellTool())
+        audit = AuditAgent(
+            dispatcher=dispatcher,
+            context=tool_context,
+            event_log=tool_context.event_log,
+            deadline=tool_context.deadline,
+        )
+        findings = await audit._run_checks()
+        assert any(f["type"] == "syntax_error" for f in findings)
+
+    @pytest.mark.asyncio
+    async def test_clean_python_passes(self, tool_context: ToolContext) -> None:
+        from noscope.tools.dispatcher import ToolDispatcher
+        from noscope.tools.shell import ShellTool
+
+        (tool_context.workspace / "requirements.txt").write_text("flask\n")
+        (tool_context.workspace / "app.py").write_text("def fine():\n    return 1\n")
+
+        dispatcher = ToolDispatcher()
+        dispatcher.register(ShellTool())
+        audit = AuditAgent(
+            dispatcher=dispatcher,
+            context=tool_context,
+            event_log=tool_context.event_log,
+            deadline=tool_context.deadline,
+        )
+        findings = await audit._run_checks()
+        assert not any(f["type"] == "syntax_error" for f in findings)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,16 +12,41 @@ from noscope.cli import app
 runner = CliRunner()
 
 
+@pytest.fixture
+def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ambient keys and no .env pickup, so doctor's verdict is the test's."""
+    for var in (
+        "NOSCOPE_ANTHROPIC_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "NOSCOPE_OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.chdir(tmp_path)
+
+
 class TestDoctorCommand:
-    def test_doctor_runs(self) -> None:
+    def test_doctor_reports_environment(self, clean_env: None) -> None:
         result = runner.invoke(app, ["doctor"])
-        assert result.exit_code == 0
         assert "NoScope Doctor" in result.output
         assert "Python" in result.output
+        assert "3.1" in result.output
 
-    def test_doctor_checks_python_version(self) -> None:
+    def test_doctor_fails_without_a_key(self, clean_env: None) -> None:
+        # doctor is meant to be usable as a gate in scripts and CI, so a missing
+        # requirement has to show up in the exit code, not just the text.
         result = runner.invoke(app, ["doctor"])
-        assert "3.1" in result.output  # Should show Python version
+        assert result.exit_code == 1
+        assert "At least one API key" in result.output
+
+    def test_doctor_passes_with_one_key(
+        self, clean_env: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Either provider alone is enough — the unset one must not fail the run.
+        monkeypatch.setenv("NOSCOPE_ANTHROPIC_API_KEY", "test-key")
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0, result.output
+        assert "All checks passed" in result.output
 
 
 class TestInitCommand:

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,0 +1,112 @@
+"""Tests for cross-agent write conflict detection."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from noscope.conflicts import WriteLedger
+from noscope.tools.base import ToolContext
+from noscope.tools.filesystem import EditFileTool, WriteFileTool
+
+
+class TestWriteLedger:
+    def test_first_write_is_never_a_conflict(self) -> None:
+        assert WriteLedger().record("app.py", "worker-1", "x = 1") is None
+
+    def test_same_agent_rewriting_its_own_file_is_fine(self) -> None:
+        ledger = WriteLedger()
+        ledger.record("app.py", "worker-1", "x = 1")
+        assert ledger.record("app.py", "worker-1", "x = 2") is None
+        assert ledger.conflicts == []
+
+    def test_different_agent_overwriting_is_a_conflict(self) -> None:
+        ledger = WriteLedger()
+        ledger.record("app.py", "worker-1", "x = 1")
+        conflict = ledger.record("app.py", "worker-2", "y = 2")
+
+        assert conflict is not None
+        assert conflict.previous_agent == "worker-1"
+        assert conflict.current_agent == "worker-2"
+        assert ledger.conflicts == [conflict]
+
+    def test_identical_content_is_not_a_conflict(self) -> None:
+        # Two agents converging on the same file content lost nothing, so
+        # warning about it would just be noise.
+        ledger = WriteLedger()
+        ledger.record("requirements.txt", "setup-deps", "flask\n")
+        assert ledger.record("requirements.txt", "setup-structure", "flask\n") is None
+        assert ledger.conflicts == []
+
+    def test_distinct_files_are_tracked_separately(self) -> None:
+        ledger = WriteLedger()
+        ledger.record("a.py", "worker-1", "a")
+        assert ledger.record("b.py", "worker-2", "b") is None
+
+    def test_summary_reports_each_path_once(self) -> None:
+        # A file clobbered repeatedly is one problem to investigate, not three.
+        ledger = WriteLedger()
+        ledger.record("app.py", "worker-1", "v1")
+        ledger.record("app.py", "worker-2", "v2")
+        ledger.record("app.py", "worker-1", "v3")
+        ledger.record("app.py", "worker-2", "v4")
+
+        summary = ledger.summary()
+        assert summary.count("app.py") == 1
+        assert "worker-1" in summary and "worker-2" in summary
+
+    def test_summary_is_empty_when_clean(self) -> None:
+        ledger = WriteLedger()
+        ledger.record("a.py", "worker-1", "a")
+        assert ledger.summary() == ""
+
+    def test_paths_touched_by_reflects_the_last_writer(self) -> None:
+        ledger = WriteLedger()
+        ledger.record("a.py", "worker-1", "a")
+        ledger.record("b.py", "worker-1", "b")
+        ledger.record("a.py", "worker-2", "a2")
+
+        assert ledger.paths_touched_by("worker-1") == ["b.py"]
+        assert ledger.paths_touched_by("worker-2") == ["a.py"]
+
+
+@pytest.mark.asyncio
+class TestConflictReachesTheAgent:
+    async def test_write_tool_warns_the_clobbering_agent(self, tool_context: ToolContext) -> None:
+        # The warning has to land in the tool output, because that is the only
+        # channel back into the agent's conversation. A conflict recorded but
+        # not surfaced would let the agent keep building on discarded work.
+        ledger = WriteLedger()
+        first = replace(tool_context, agent_id="worker-1", write_ledger=ledger)
+        second = replace(tool_context, agent_id="worker-2", write_ledger=ledger)
+        tool = WriteFileTool()
+
+        clean = await tool.execute({"path": "app.py", "content": "v1"}, first)
+        assert "warning" not in clean.display
+
+        clobber = await tool.execute({"path": "app.py", "content": "v2"}, second)
+        assert clobber.status == "ok"  # warned, not blocked
+        assert "worker-1" in clobber.display
+        assert "read the file back" in clobber.display
+
+    async def test_edit_tool_also_records(self, tool_context: ToolContext) -> None:
+        ledger = WriteLedger()
+        first = replace(tool_context, agent_id="worker-1", write_ledger=ledger)
+        second = replace(tool_context, agent_id="worker-2", write_ledger=ledger)
+
+        await WriteFileTool().execute({"path": "app.py", "content": "x = 1\n"}, first)
+        result = await EditFileTool().execute(
+            {"path": "app.py", "old_string": "x = 1", "new_string": "x = 2"}, second
+        )
+        assert result.status == "ok"
+        assert len(ledger.conflicts) == 1
+        assert ledger.conflicts[0].path == "app.py"
+
+    async def test_no_ledger_means_no_behavior_change(self, tool_context: ToolContext) -> None:
+        # Contexts without a ledger (single-agent paths, older call sites) must
+        # keep working exactly as before.
+        ctx = replace(tool_context, write_ledger=None)
+        result = await WriteFileTool().execute({"path": "a.py", "content": "x"}, ctx)
+        assert result.status == "ok"
+        assert "warning" not in result.display

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,107 @@
+"""Tests for conversation context management."""
+
+from __future__ import annotations
+
+from noscope.context import (
+    MAX_TOOL_RESULT_CHARS,
+    trim_history,
+    truncate_tool_output,
+)
+from noscope.llm.base import Message, ToolCall
+
+
+class TestTruncateToolOutput:
+    def test_short_output_untouched(self) -> None:
+        assert truncate_tool_output("hello") == "hello"
+
+    def test_long_output_keeps_head_and_tail(self) -> None:
+        text = "START" + ("x" * 50_000) + "END"
+        out = truncate_tool_output(text)
+        assert len(out) < len(text)
+        # Errors usually live at the start or end, so both survive.
+        assert out.startswith("START")
+        assert out.endswith("END")
+        assert "characters omitted" in out
+
+    def test_respects_custom_limit(self) -> None:
+        assert len(truncate_tool_output("y" * 1000, limit=100)) < 200
+
+    def test_default_limit_is_applied(self) -> None:
+        out = truncate_tool_output("z" * (MAX_TOOL_RESULT_CHARS * 3))
+        assert len(out) < MAX_TOOL_RESULT_CHARS * 2
+
+
+def _conversation(turns: int, filler: int = 5_000) -> list[Message]:
+    """system + briefing, then `turns` of (assistant tool_call -> tool result)."""
+    msgs: list[Message] = [
+        Message(role="system", content="You are a builder."),
+        Message(role="user", content="Build the thing."),
+    ]
+    for i in range(turns):
+        msgs.append(
+            Message(
+                role="assistant",
+                content=f"step {i}",
+                tool_calls=[ToolCall(id=f"c{i}", name="read_file", arguments={"path": "a.py"})],
+            )
+        )
+        msgs.append(Message(role="tool", content="x" * filler, tool_call_id=f"c{i}"))
+    return msgs
+
+
+class TestTrimHistory:
+    def test_short_history_untouched(self) -> None:
+        msgs = _conversation(2, filler=10)
+        assert trim_history(msgs) is msgs
+
+    def test_long_history_is_trimmed(self) -> None:
+        msgs = _conversation(200)
+        trimmed = trim_history(msgs)
+        assert len(trimmed) < len(msgs)
+
+    def test_preserves_system_and_briefing(self) -> None:
+        msgs = _conversation(200)
+        trimmed = trim_history(msgs)
+        assert trimmed[0].role == "system"
+        assert trimmed[1].role == "user"
+        assert trimmed[1].content == "Build the thing."
+
+    def test_never_orphans_a_tool_result(self) -> None:
+        # A tool result whose assistant turn was dropped is an API error, so the
+        # kept tail must never begin with a tool message.
+        for turns in range(20, 120, 7):
+            trimmed = trim_history(_conversation(turns), max_chars=20_000)
+            after_preamble = [m for m in trimmed[2:] if m.role != "user" or m.content]
+            first_non_note = next(
+                (m for m in after_preamble if "were dropped" not in (m.content or "")), None
+            )
+            if first_non_note is not None:
+                assert first_non_note.role != "tool"
+
+    def test_keeps_the_most_recent_turns(self) -> None:
+        msgs = _conversation(50)
+        msgs.append(Message(role="user", content="LATEST INSTRUCTION"))
+        trimmed = trim_history(msgs, max_chars=20_000)
+        assert trimmed[-1].content == "LATEST INSTRUCTION"
+
+    def test_notes_the_elision(self) -> None:
+        trimmed = trim_history(_conversation(100), max_chars=20_000)
+        assert any("were dropped" in (m.content or "") for m in trimmed)
+
+    def test_oversized_preamble_still_returns_valid_history(self) -> None:
+        msgs = [
+            Message(role="system", content="s" * 60_000),
+            Message(role="user", content="u" * 60_000),
+            Message(
+                role="assistant",
+                content="go",
+                tool_calls=[ToolCall(id="c", name="t", arguments={})],
+            ),
+            Message(role="tool", content="result", tool_call_id="c"),
+        ]
+        trimmed = trim_history(msgs, max_chars=1_000)
+        assert trimmed[0].role == "system"
+        # Whatever survives must not start with an orphaned tool result.
+        tail = trimmed[2:]
+        if tail:
+            assert tail[0].role != "tool"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,69 @@
+"""Tests for actionable API error explanations."""
+
+from __future__ import annotations
+
+from noscope.errors import explain_error, format_run_error
+
+
+class _FakeError(Exception):
+    """Stand-in for an SDK exception (matched by class name / status)."""
+
+    def __init__(self, name: str, status: int | None = None, msg: str = "boom") -> None:
+        super().__init__(msg)
+        self.__class__.__name__ = name
+        if status is not None:
+            self.status_code = status
+
+
+class TestExplainError:
+    def test_auth_error_names_the_env_var(self) -> None:
+        out = explain_error(_FakeError("AuthenticationError"), provider="anthropic")
+        assert out is not None
+        assert "NOSCOPE_ANTHROPIC_API_KEY" in out
+        assert "doctor --live" in out
+
+    def test_auth_error_is_provider_specific(self) -> None:
+        out = explain_error(_FakeError("AuthenticationError"), provider="openai")
+        assert out is not None
+        assert "NOSCOPE_OPENAI_API_KEY" in out
+
+    def test_model_not_found_suggests_current_models(self) -> None:
+        out = explain_error(_FakeError("NotFoundError"), model="claude-old")
+        assert out is not None
+        assert "claude-old" in out
+        assert "claude-sonnet-5" in out
+
+    def test_rate_limit(self) -> None:
+        out = explain_error(_FakeError("RateLimitError"))
+        assert out is not None
+        assert "Rate limited" in out
+        assert "--workers" in out
+
+    def test_overloaded_by_status(self) -> None:
+        out = explain_error(_FakeError("APIStatusError", status=529))
+        assert out is not None
+        assert "overloaded" in out.lower()
+
+    def test_matches_on_status_when_name_is_unknown(self) -> None:
+        # Providers rename exception classes; the HTTP status still identifies it.
+        out = explain_error(_FakeError("SomeNewSdkError", status=401))
+        assert out is not None
+        assert "rejected your credentials" in out
+
+    def test_connection_error(self) -> None:
+        assert explain_error(_FakeError("APIConnectionError")) is not None
+
+    def test_unknown_error_returns_none(self) -> None:
+        assert explain_error(ValueError("something else")) is None
+
+
+class TestFormatRunError:
+    def test_known_error_includes_diagnosis_and_details(self) -> None:
+        out = format_run_error(_FakeError("AuthenticationError", msg="bad key"), provider="anthropic")
+        assert "NOSCOPE_ANTHROPIC_API_KEY" in out
+        assert "bad key" in out
+
+    def test_unknown_error_still_readable(self) -> None:
+        out = format_run_error(ValueError("plain problem"))
+        assert "ValueError" in out
+        assert "plain problem" in out

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -59,7 +59,9 @@ class TestExplainError:
 
 class TestFormatRunError:
     def test_known_error_includes_diagnosis_and_details(self) -> None:
-        out = format_run_error(_FakeError("AuthenticationError", msg="bad key"), provider="anthropic")
+        out = format_run_error(
+            _FakeError("AuthenticationError", msg="bad key"), provider="anthropic"
+        )
         assert "NOSCOPE_ANTHROPIC_API_KEY" in out
         assert "bad key" in out
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -69,3 +69,13 @@ class TestFormatRunError:
         out = format_run_error(ValueError("plain problem"))
         assert "ValueError" in out
         assert "plain problem" in out
+
+
+class TestRequestTimeoutExplanation:
+    def test_request_timeout_names_the_knob(self) -> None:
+        from noscope.llm.bounded import RequestTimeoutError
+
+        out = explain_error(RequestTimeoutError("timed out"))
+        assert out is not None
+        assert "NOSCOPE_REQUEST_TIMEOUT" in out
+        assert "--time" in out

--- a/tests/test_llm/test_bounded.py
+++ b/tests/test_llm/test_bounded.py
@@ -1,0 +1,85 @@
+"""Tests for the deadline-bound provider wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from noscope.deadline import Deadline
+from noscope.llm.base import LLMResponse, Message, Usage
+from noscope.llm.bounded import (
+    MIN_REQUEST_TIMEOUT,
+    DeadlineBoundProvider,
+    RequestTimeoutError,
+)
+
+
+class _SlowProvider:
+    """Blocks for `delay` seconds, recording the kwargs it was handed."""
+
+    def __init__(self, delay: float = 0.0) -> None:
+        self.delay = delay
+        self.calls: list[dict[str, Any]] = []
+        self.provider_specific = "passthrough-value"
+
+    async def complete(self, messages: list[Message], **kwargs: Any) -> LLMResponse:
+        self.calls.append(kwargs)
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return LLMResponse(content="ok", usage=Usage())
+
+
+@pytest.mark.asyncio
+class TestDeadlineBoundProvider:
+    async def test_fast_calls_pass_straight_through(self) -> None:
+        inner = _SlowProvider()
+        p = DeadlineBoundProvider(inner, Deadline(300))
+        result = await p.complete([Message(role="user", content="hi")], effort="high")
+
+        assert result.content == "ok"
+        assert inner.calls[0]["effort"] == "high"
+
+    async def test_a_stalled_request_is_abandoned(self) -> None:
+        # Without this, a hung request outlives the timebox entirely: the SDKs
+        # default to a 600s read timeout and retry on top of that, and the
+        # deadline is only checked between agent iterations.
+        p = DeadlineBoundProvider(_SlowProvider(delay=5), Deadline(300), max_seconds=0.05)
+
+        with pytest.raises(RequestTimeoutError) as exc:
+            await p.complete([Message(role="user", content="hi")])
+        assert "did not respond" in str(exc.value)
+
+    async def test_timeout_is_capped_by_max_seconds(self) -> None:
+        # Lots of timebox left, so the configured cap is what binds.
+        p = DeadlineBoundProvider(_SlowProvider(), Deadline(3600), max_seconds=90)
+        assert p.timeout_for_now() == 90
+
+    async def test_timeout_shrinks_with_the_remaining_timebox(self) -> None:
+        p = DeadlineBoundProvider(_SlowProvider(), Deadline(60), max_seconds=120)
+        # 60s left, 120s cap -> the deadline is the binding constraint.
+        assert MIN_REQUEST_TIMEOUT < p.timeout_for_now() <= 60
+
+    async def test_handoff_still_gets_time_after_the_deadline(self) -> None:
+        # HANDOFF runs *after* the deadline on purpose — the "always produce
+        # output" guarantee. A zero-length timeout there would mean an expired
+        # run silently produces no report at all.
+        expired = Deadline(0)
+        p = DeadlineBoundProvider(_SlowProvider(), expired)
+
+        assert expired.remaining() == 0
+        assert p.timeout_for_now() == MIN_REQUEST_TIMEOUT
+
+        result = await p.complete([Message(role="user", content="write the report")])
+        assert result.content == "ok"
+
+    async def test_unknown_attributes_reach_the_wrapped_provider(self) -> None:
+        p = DeadlineBoundProvider(_SlowProvider(), Deadline(300))
+        assert p.provider_specific == "passthrough-value"
+
+    async def test_configured_cap_beats_the_floor(self) -> None:
+        # The floor guards against an expired deadline, not against a small
+        # request_timeout the operator chose on purpose.
+        p = DeadlineBoundProvider(_SlowProvider(), Deadline(3600), max_seconds=5)
+        assert p.timeout_for_now() == 5

--- a/tests/test_llm/test_provider_calls.py
+++ b/tests/test_llm/test_provider_calls.py
@@ -1,0 +1,276 @@
+"""Provider request/response shape tests against mocked SDK clients.
+
+These never touch the network. They pin the wire shapes NoScope sends and the
+parsing of what comes back — the layer most likely to break silently when a
+provider SDK changes, and the one that costs real tokens to discover live.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from noscope.llm.base import Message, ToolCall, ToolSchema
+from noscope.llm.providers.anthropic import AnthropicProvider
+from noscope.llm.providers.openai import OpenAIProvider
+
+
+class _RecordingMessages:
+    """Stands in for client.messages, capturing kwargs and returning a reply."""
+
+    def __init__(self, reply: Any, fail_times: int = 0, fail_with: type | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._reply = reply
+        self._fail_times = fail_times
+        self._fail_with = fail_with
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if self._fail_times > 0:
+            self._fail_times -= 1
+            assert self._fail_with is not None
+            raise self._fail_with.__new__(self._fail_with)
+        return self._reply
+
+
+def _anthropic_reply(
+    blocks: list[Any] | None = None,
+    stop_reason: str = "end_turn",
+    cache_read: int = 0,
+    cache_write: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        content=blocks if blocks is not None else [SimpleNamespace(type="text", text="hi")],
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_write,
+        ),
+        stop_reason=stop_reason,
+    )
+
+
+def _provider(reply: Any, **kw: Any) -> tuple[AnthropicProvider, _RecordingMessages]:
+    p = AnthropicProvider(api_key="test", **kw)
+    msgs = _RecordingMessages(reply)
+    p._client = SimpleNamespace(messages=msgs)  # type: ignore[assignment]
+    return p, msgs
+
+
+@pytest.mark.asyncio
+class TestAnthropicRequestShape:
+    async def test_system_prompt_is_cached_block(self) -> None:
+        p, msgs = _provider(_anthropic_reply())
+        await p.complete(
+            [Message(role="system", content="be helpful"), Message(role="user", content="hi")]
+        )
+        sent = msgs.calls[0]
+        assert sent["system"][0]["text"] == "be helpful"
+        # A cache breakpoint on the stable system prompt is the main cost lever.
+        assert sent["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+    async def test_tools_are_converted_and_last_one_cached(self) -> None:
+        p, msgs = _provider(_anthropic_reply())
+        tools = [
+            ToolSchema(name="a", description="da", parameters={"type": "object"}),
+            ToolSchema(name="b", description="db", parameters={"type": "object"}),
+        ]
+        await p.complete([Message(role="user", content="hi")], tools=tools)
+        sent_tools = msgs.calls[0]["tools"]
+        assert [t["name"] for t in sent_tools] == ["a", "b"]
+        assert "input_schema" in sent_tools[0]
+        assert sent_tools[-1]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in sent_tools[0]
+
+    async def test_thinking_and_effort_are_sent(self) -> None:
+        p, msgs = _provider(_anthropic_reply())
+        await p.complete([Message(role="user", content="hi")], effort="high")
+        sent = msgs.calls[0]
+        assert sent["thinking"] == {"type": "adaptive"}
+        assert sent["output_config"]["effort"] == "high"
+
+    async def test_structured_output_schema_is_prepared(self) -> None:
+        p, msgs = _provider(_anthropic_reply())
+        schema = {"type": "object", "title": "X", "properties": {"a": {"type": "string"}}}
+        await p.complete([Message(role="user", content="hi")], json_schema=schema)
+        fmt = msgs.calls[0]["output_config"]["format"]
+        assert fmt["type"] == "json_schema"
+        # additionalProperties is required by structured outputs; Pydantic omits it.
+        assert fmt["schema"]["additionalProperties"] is False
+
+    async def test_tool_results_become_user_messages(self) -> None:
+        p, msgs = _provider(_anthropic_reply())
+        await p.complete(
+            [
+                Message(role="user", content="go"),
+                Message(
+                    role="assistant",
+                    content="calling",
+                    tool_calls=[ToolCall(id="c1", name="t", arguments={"x": 1})],
+                ),
+                Message(role="tool", content="result text", tool_call_id="c1"),
+            ]
+        )
+        sent = msgs.calls[0]["messages"]
+        assert sent[1]["role"] == "assistant"
+        assert any(b["type"] == "tool_use" for b in sent[1]["content"])
+        assert sent[2]["role"] == "user"
+        assert sent[2]["content"][0]["type"] == "tool_result"
+        assert sent[2]["content"][0]["tool_use_id"] == "c1"
+
+
+@pytest.mark.asyncio
+class TestAnthropicResponseParsing:
+    async def test_text_and_tool_use_are_parsed(self) -> None:
+        blocks = [
+            SimpleNamespace(type="text", text="thinking out loud"),
+            SimpleNamespace(type="tool_use", id="c9", name="write_file", input={"path": "a"}),
+        ]
+        p, _ = _provider(_anthropic_reply(blocks=blocks, stop_reason="tool_use"))
+        r = await p.complete([Message(role="user", content="hi")])
+        assert r.content == "thinking out loud"
+        assert r.tool_calls[0].id == "c9"
+        assert r.tool_calls[0].name == "write_file"
+        assert r.tool_calls[0].arguments == {"path": "a"}
+        assert r.stop_reason == "tool_use"
+
+    async def test_cache_tokens_are_captured(self) -> None:
+        p, _ = _provider(_anthropic_reply(cache_read=900, cache_write=100))
+        r = await p.complete([Message(role="user", content="hi")])
+        assert r.usage.cache_read_input_tokens == 900
+        assert r.usage.cache_creation_input_tokens == 100
+        assert r.usage.input_tokens == 10
+
+
+@pytest.mark.asyncio
+class TestAnthropicDegradation:
+    async def test_falls_back_when_modern_params_rejected(self) -> None:
+        import anthropic
+
+        p = AnthropicProvider(api_key="test")
+        msgs = _RecordingMessages(
+            _anthropic_reply(), fail_times=2, fail_with=anthropic.BadRequestError
+        )
+        p._client = SimpleNamespace(messages=msgs)  # type: ignore[assignment]
+
+        schema = {"type": "object", "properties": {}}
+        r = await p.complete([Message(role="user", content="hi")], json_schema=schema)
+
+        # 1) full modern -> 400, 2) without schema -> 400, 3) plain request succeeds.
+        assert len(msgs.calls) == 3
+        assert "output_config" not in msgs.calls[2]
+        assert "thinking" not in msgs.calls[2]
+        assert r.content == "hi"
+
+    async def test_degradation_is_remembered(self) -> None:
+        import anthropic
+
+        p = AnthropicProvider(api_key="test")
+        # No schema here, so the fallback is just: modern -> plain (one failure).
+        msgs = _RecordingMessages(
+            _anthropic_reply(), fail_times=1, fail_with=anthropic.BadRequestError
+        )
+        p._client = SimpleNamespace(messages=msgs)  # type: ignore[assignment]
+        await p.complete([Message(role="user", content="hi")])
+        first_round = len(msgs.calls)
+        assert first_round == 2
+
+        await p.complete([Message(role="user", content="again")])
+        # The second call must not re-pay the failed-request tax.
+        assert len(msgs.calls) == first_round + 1
+
+
+class _RecordingCompletions:
+    def __init__(self, reply: Any) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._reply = reply
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self._reply
+
+
+def _openai_reply(
+    content: str = "hello",
+    finish_reason: str = "stop",
+    tool_calls: list[Any] | None = None,
+    cached: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=tool_calls),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached),
+        ),
+    )
+
+
+def _openai_provider(reply: Any) -> tuple[OpenAIProvider, _RecordingCompletions]:
+    p = OpenAIProvider(api_key="test")
+    comps = _RecordingCompletions(reply)
+    p._client = SimpleNamespace(chat=SimpleNamespace(completions=comps))  # type: ignore[assignment]
+    return p, comps
+
+
+@pytest.mark.asyncio
+class TestOpenAIProvider:
+    async def test_stop_reason_is_normalized(self) -> None:
+        # The agent loops exit on "end_turn"; OpenAI says "stop".
+        p, _ = _openai_provider(_openai_reply(finish_reason="stop"))
+        assert (await p.complete([Message(role="user", content="hi")])).stop_reason == "end_turn"
+
+    async def test_tool_calls_finish_reason_maps(self) -> None:
+        p, _ = _openai_provider(_openai_reply(finish_reason="tool_calls"))
+        assert (await p.complete([Message(role="user", content="hi")])).stop_reason == "tool_use"
+
+    async def test_tools_use_function_envelope(self) -> None:
+        p, comps = _openai_provider(_openai_reply())
+        await p.complete(
+            [Message(role="user", content="hi")],
+            tools=[ToolSchema(name="t", description="d", parameters={"type": "object"})],
+        )
+        tool = comps.calls[0]["tools"][0]
+        assert tool["type"] == "function"
+        assert tool["function"]["name"] == "t"
+
+    async def test_json_schema_is_enforced_not_discarded(self) -> None:
+        p, comps = _openai_provider(_openai_reply())
+        await p.complete(
+            [Message(role="user", content="hi")],
+            json_schema={"type": "object", "properties": {}},
+        )
+        fmt = comps.calls[0]["response_format"]
+        # The old code sent bare {"type": "json_object"} and dropped the schema.
+        assert fmt["type"] == "json_schema"
+        assert "schema" in fmt["json_schema"]
+
+    async def test_cached_tokens_split_out_of_prompt_tokens(self) -> None:
+        p, _ = _openai_provider(_openai_reply(cached=60))
+        usage = (await p.complete([Message(role="user", content="hi")])).usage
+        # OpenAI counts cached tokens inside prompt_tokens; we report the
+        # uncached remainder separately to match Anthropic's convention.
+        assert usage.input_tokens == 40
+        assert usage.cache_read_input_tokens == 60
+
+    async def test_tool_call_arguments_are_parsed(self) -> None:
+        tc = SimpleNamespace(
+            id="c1", function=SimpleNamespace(name="write_file", arguments='{"path": "a.py"}')
+        )
+        p, _ = _openai_provider(_openai_reply(content=None, tool_calls=[tc]))
+        r = await p.complete([Message(role="user", content="hi")])
+        assert r.tool_calls[0].arguments == {"path": "a.py"}
+
+    async def test_malformed_tool_arguments_do_not_crash(self) -> None:
+        tc = SimpleNamespace(id="c1", function=SimpleNamespace(name="x", arguments="not json"))
+        p, _ = _openai_provider(_openai_reply(content=None, tool_calls=[tc]))
+        r = await p.complete([Message(role="user", content="hi")])
+        assert r.tool_calls[0].arguments == {}

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2,8 +2,176 @@
 
 from __future__ import annotations
 
+import asyncio
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from noscope.llm.base import LLMResponse, Message, ToolCall, ToolSchema, Usage
 from noscope.planning.models import AcceptancePlan, PlanOutput, PlanTask
 from noscope.spec.models import AcceptanceCheck, SpecInput
+
+# A minimal, valid plan the scripted provider returns for the PLAN phase.
+_PLAN_JSON = json.dumps(
+    {
+        "requested_capabilities": [
+            {"cap": "workspace_rw", "why": "write files", "risk": "low"},
+            {"cap": "shell_exec", "why": "run checks", "risk": "medium"},
+        ],
+        "tasks": [
+            {
+                "id": "t1",
+                "title": "Set up project",
+                "kind": "edit",
+                "priority": "mvp",
+                "description": "create app.py",
+                "depends_on": [],
+            }
+        ],
+        "mvp_definition": ["app.py exists"],
+        "exclusions": [],
+        "acceptance_plan": [{"name": "app exists", "cmd": "test -f app.py", "must_pass": True}],
+    }
+)
+
+
+class ScriptedProvider:
+    """A fake provider that drives every phase of a full run deterministically.
+
+    It decides what to return from the call's shape — a structured-output
+    request is the planner, a tool set containing confirm_running is VERIFY, one
+    containing mark_task_complete is a build agent, and a plain call is HANDOFF.
+    No network, no API key.
+    """
+
+    def __init__(self) -> None:
+        self._structure_calls = 0
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        model: str | None = None,
+        json_schema: dict[str, Any] | None = None,
+        effort: str | None = None,
+    ) -> LLMResponse:
+        system = messages[0].content if messages else ""
+        names = {t.name for t in (tools or [])}
+
+        if json_schema is not None:  # PLAN
+            return LLMResponse(content=_PLAN_JSON, usage=Usage(input_tokens=50, output_tokens=50))
+
+        if "confirm_running" in names:  # VERIFY — propose a proof the harness runs
+            return LLMResponse(
+                tool_calls=[
+                    ToolCall(
+                        id="v1",
+                        name="confirm_running",
+                        arguments={"command": "test -f app.py", "summary": "app.py present"},
+                    )
+                ],
+                usage=Usage(input_tokens=20, output_tokens=10),
+            )
+
+        if "mark_task_complete" in names:  # BUILD agent
+            if "DEPS agent" in system:  # the deps agent has nothing to do here
+                return LLMResponse(content="deps ready", stop_reason="end_turn", usage=Usage())
+            # structure agent: write the file, then mark the task done
+            self._structure_calls += 1
+            if self._structure_calls == 1:
+                return LLMResponse(
+                    tool_calls=[
+                        ToolCall(
+                            id="w1",
+                            name="write_file",
+                            arguments={"path": "app.py", "content": "print('hello')\n"},
+                        )
+                    ],
+                    usage=Usage(input_tokens=30, output_tokens=20),
+                )
+            return LLMResponse(
+                tool_calls=[
+                    ToolCall(id="m1", name="mark_task_complete", arguments={"task_id": "t1"})
+                ],
+                usage=Usage(input_tokens=10, output_tokens=5),
+            )
+
+        # HANDOFF — a plain call with no tools and no schema
+        return LLMResponse(
+            content="# Handoff\n\nBuilt app.py.\n",
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=40, output_tokens=30),
+        )
+
+
+class TestFullPipeline:
+    def test_run_produces_verified_artifact_and_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Run entirely inside a temp cwd so .noscope/ and outputs stay isolated,
+        # and give settings a dummy key so the provider constructs (no network).
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("NOSCOPE_ANTHROPIC_API_KEY", "test-key")
+
+        from noscope.config.settings import load_settings
+        from noscope.orchestrator import Orchestrator
+
+        orch = Orchestrator(load_settings(), console=Console(file=io.StringIO()))
+        orch.provider = ScriptedProvider()  # type: ignore[assignment]
+
+        spec = SpecInput(name="Demo", timebox="5m")
+        workspace = tmp_path / "out"
+        run_path = asyncio.run(orch.run(spec_input=spec, output_dir=workspace, auto_approve=True))
+
+        # The build produced the artifact...
+        assert (workspace / "app.py").exists()
+        # ...and the run directory holds the full record, always including a report.
+        assert (run_path / "plan.json").exists()
+        assert (run_path / "contract.json").exists()
+        handoff = (run_path / "handoff.md").read_text()
+        assert handoff.strip()
+
+        # The event log proves the pipeline reached an independently-confirmed
+        # verification and ran to completion.
+        events = (run_path / "events.jsonl").read_text()
+        types = {json.loads(line)["type"] for line in events.splitlines() if line.strip()}
+        assert "verify.pass" in types
+        assert "run.complete" in types
+        assert "acceptance.check" in types
+
+    def test_handoff_runs_even_when_planning_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If a phase raises, the run must still produce a handoff report —
+        # the "always produce output" guarantee.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("NOSCOPE_ANTHROPIC_API_KEY", "test-key")
+
+        from noscope.config.settings import load_settings
+        from noscope.orchestrator import Orchestrator
+
+        class ExplodingProvider(ScriptedProvider):
+            async def complete(self, messages: Any, **kw: Any) -> LLMResponse:
+                if kw.get("json_schema") is not None:
+                    raise RuntimeError("planner boom")
+                return await super().complete(messages, **kw)
+
+        orch = Orchestrator(load_settings(), console=Console(file=io.StringIO()))
+        orch.provider = ExplodingProvider()  # type: ignore[assignment]
+
+        run_path = asyncio.run(
+            orch.run(
+                spec_input=SpecInput(name="Demo", timebox="5m"),
+                output_dir=tmp_path / "out",
+                auto_approve=True,
+            )
+        )
+        # Even though PLAN raised, a handoff report exists.
+        assert (run_path / "handoff.md").read_text().strip()
 
 
 class TestPlanOutput:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -143,6 +143,50 @@ class TestFullPipeline:
         assert "run.complete" in types
         assert "acceptance.check" in types
 
+    def test_sandbox_preflight_aborts_before_spending_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An unusable --sandbox must stop the run *before* PLAN. Discovering it
+        # mid-build wastes both the timebox and the tokens already spent.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("NOSCOPE_ANTHROPIC_API_KEY", "test-key")
+
+        async def no_docker(timeout: float = 15.0) -> str:
+            return "Docker is not available in this test."
+
+        monkeypatch.setattr("noscope.orchestrator.preflight_docker", no_docker)
+
+        from noscope.config.settings import load_settings
+        from noscope.orchestrator import Orchestrator
+
+        calls = 0
+
+        class _CountingProvider(ScriptedProvider):
+            async def complete(self, *args: Any, **kwargs: Any) -> LLMResponse:
+                nonlocal calls
+                calls += 1
+                return await super().complete(*args, **kwargs)
+
+        orch = Orchestrator(load_settings(), console=Console(file=io.StringIO()))
+        orch.provider = _CountingProvider()  # type: ignore[assignment]
+
+        run_path = asyncio.run(
+            orch.run(
+                spec_input=SpecInput(name="Demo", timebox="5m"),
+                output_dir=tmp_path / "out",
+                sandbox=True,
+                auto_approve=True,
+            )
+        )
+
+        types = [
+            json.loads(line)["type"]
+            for line in (run_path / "events.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+        assert "run.aborted" in types
+        assert calls == 0, "aborted before PLAN, so no model call should have happened"
+
     def test_handoff_runs_even_when_planning_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -206,3 +206,59 @@ class TestSpecInput:
         )
         assert spec.acceptance[0].is_cmd is True
         assert spec.acceptance[1].is_cmd is False
+
+
+class TestDryRun:
+    def test_dry_run_completes_without_a_provider(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The whole pipeline must run with no API key and no network: this is
+        # the smoke test users run before spending tokens.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("NOSCOPE_ANTHROPIC_API_KEY", "dry-run")
+
+        from noscope.config.settings import load_settings
+        from noscope.llm.dryrun import DRY_RUN_FILE
+        from noscope.orchestrator import Orchestrator
+
+        orch = Orchestrator(load_settings(), console=Console(file=io.StringIO()), dry_run=True)
+        workspace = tmp_path / "out"
+        run_path = asyncio.run(
+            orch.run(
+                spec_input=SpecInput(name="Dry", timebox="3m"),
+                output_dir=workspace,
+                auto_approve=True,
+            )
+        )
+
+        assert (workspace / DRY_RUN_FILE).exists()
+        assert (run_path / "handoff.md").read_text().strip()
+        events = (run_path / "events.jsonl").read_text()
+        types = {json.loads(line)["type"] for line in events.splitlines() if line.strip()}
+        assert "verify.pass" in types
+        assert "run.complete" in types
+
+    def test_dry_run_spends_no_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("NOSCOPE_ANTHROPIC_API_KEY", "dry-run")
+
+        from noscope.config.settings import load_settings
+        from noscope.orchestrator import Orchestrator
+
+        orch = Orchestrator(load_settings(), console=Console(file=io.StringIO()), dry_run=True)
+        run_path = asyncio.run(
+            orch.run(
+                spec_input=SpecInput(name="Dry", timebox="3m"),
+                output_dir=tmp_path / "out",
+                auto_approve=True,
+            )
+        )
+        complete = [
+            json.loads(line)
+            for line in (run_path / "events.jsonl").read_text().splitlines()
+            if line.strip() and json.loads(line)["type"] == "run.complete"
+        ][0]
+        assert complete["data"]["input_tokens"] == 0
+        assert complete["data"]["output_tokens"] == 0

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -243,3 +244,55 @@ class TestHandoffPhase:
         assert "Test" in report
         assert "Build it" in report
         event_log.close()
+
+    async def test_write_conflicts_are_appended_not_prompted(self, tmp_path: Path) -> None:
+        # The body of the report is model-written, so a conflict passed as a
+        # prompt hint could simply be left out. Overwritten work is exactly the
+        # gap a handoff must name, so it's appended after generation instead.
+        class _Provider:
+            async def complete(self, messages: Any, **kwargs: Any) -> LLMResponse:
+                return LLMResponse(content="# Report\n\nAll good.", usage=Usage())
+
+        rd = RunDir(base=tmp_path / "runs")
+        event_log = EventLog(rd)
+        out = tmp_path / "handoff.md"
+
+        report = await HandoffPhase().run(
+            SpecInput(name="Test", timebox="5m"),
+            PlanOutput(tasks=[]),
+            [],
+            [],
+            _Provider(),  # type: ignore[arg-type]
+            event_log,
+            Deadline(300),
+            out,
+            write_conflicts="app.py was written by worker-1, then overwritten by worker-2",
+        )
+        event_log.close()
+
+        assert "Parallel Write Conflicts" in report
+        assert "worker-1" in report
+        # And it reached disk, not just the return value.
+        assert "worker-2" in out.read_text()
+
+    async def test_no_conflicts_means_no_extra_section(self, tmp_path: Path) -> None:
+        class _Provider:
+            async def complete(self, messages: Any, **kwargs: Any) -> LLMResponse:
+                return LLMResponse(content="# Report\n\nAll good.", usage=Usage())
+
+        rd = RunDir(base=tmp_path / "runs")
+        event_log = EventLog(rd)
+
+        report = await HandoffPhase().run(
+            SpecInput(name="Test", timebox="5m"),
+            PlanOutput(tasks=[]),
+            [],
+            [],
+            _Provider(),  # type: ignore[arg-type]
+            event_log,
+            Deadline(300),
+            tmp_path / "handoff.md",
+        )
+        event_log.close()
+
+        assert "Parallel Write Conflicts" not in report

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -170,3 +170,20 @@ class TestSlugify:
         from noscope.spec.parser import slugify
 
         assert slugify("!!!") == "spec"
+
+
+class TestShippedExamples:
+    """Every example in examples/ must parse — they're the first thing anyone runs."""
+
+    def test_all_examples_parse(self) -> None:
+        from noscope.spec.parser import parse_spec
+
+        examples = sorted((Path(__file__).parent.parent / "examples").glob("*.md"))
+        assert examples, "examples/ should not be empty"
+
+        for path in examples:
+            spec = parse_spec(path)
+            assert spec.name.strip(), f"{path.name} has no name"
+            assert spec.timebox_seconds > 0, f"{path.name} has no usable timebox"
+            assert spec.body.strip(), f"{path.name} has an empty body"
+            assert spec.acceptance, f"{path.name} defines no acceptance checks"

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -111,3 +111,62 @@ Body here.
         assert result.repo_mode == "existing"
         assert result.risk_policy == "strict"
         assert result.body.strip() == "Body here."
+
+
+class TestSpecFileGeneration:
+    def test_round_trips_through_the_parser(self, tmp_path: Path) -> None:
+        from noscope.spec.parser import build_spec_file
+
+        content = build_spec_file(
+            name="My Project",
+            timebox="10m",
+            constraints=["Use Python"],
+            acceptance=["cmd: pytest -q"],
+            body="# My Project\n\nDo the thing.",
+        )
+        path = tmp_path / "s.md"
+        path.write_text(content, encoding="utf-8")
+        spec = parse_spec(path)
+        assert spec.name == "My Project"
+        assert spec.timebox == "10m"
+        assert spec.constraints == ["Use Python"]
+        assert spec.acceptance[0].command == "pytest -q"
+
+    def test_quotes_and_colons_survive(self, tmp_path: Path) -> None:
+        # The old hand-built f-string frontmatter produced invalid YAML here.
+        from noscope.spec.parser import build_spec_file
+
+        tricky = 'The "Best" App: v2'
+        path = tmp_path / "s.md"
+        path.write_text(
+            build_spec_file(
+                name=tricky,
+                timebox="5m",
+                constraints=['Must say "hello"', "Use A: B"],
+                acceptance=[],
+                body="body",
+            ),
+            encoding="utf-8",
+        )
+        spec = parse_spec(path)
+        assert spec.name == tricky
+        assert spec.constraints == ['Must say "hello"', "Use A: B"]
+
+
+class TestSlugify:
+    def test_basic(self) -> None:
+        from noscope.spec.parser import slugify
+
+        assert slugify("My Project") == "my-project"
+
+    def test_strips_unsafe_characters(self) -> None:
+        from noscope.spec.parser import slugify
+
+        # A name with a path separator must not escape into a directory.
+        assert "/" not in slugify("a/../b")
+        assert slugify('The "Best": v2!') == "the-best-v2"
+
+    def test_falls_back_when_empty(self) -> None:
+        from noscope.spec.parser import slugify
+
+        assert slugify("!!!") == "spec"

--- a/tests/test_supervisor_run.py
+++ b/tests/test_supervisor_run.py
@@ -248,3 +248,65 @@ class TestSupervisorRun:
 
         assert context.deadline.total_seconds >= 60, "fixture must have a long deadline to matter"
         assert elapsed < 10, f"supervisor blocked on the audit agent for {elapsed:.1f}s"
+
+
+class _FlakyProvider(_WorkerProvider):
+    """Fails the first `fail_first` calls, then behaves normally."""
+
+    def __init__(self, fail_first: int) -> None:
+        super().__init__()
+        self._remaining_failures = fail_first
+
+    async def complete(self, messages: list[Message], **kwargs: Any) -> LLMResponse:
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise RuntimeError("transient upstream error")
+        return await super().complete(messages, **kwargs)
+
+
+class _AlwaysFailingProvider(_WorkerProvider):
+    async def complete(self, messages: list[Message], **kwargs: Any) -> LLMResponse:
+        self.calls += 1
+        raise RuntimeError("upstream is down")
+
+
+@pytest.mark.asyncio
+class TestAgentResilience:
+    def _supervisor(self, provider: Any, context: ToolContext, event_log: EventLog) -> Supervisor:
+        return Supervisor(
+            provider=provider,
+            dispatcher=_dispatcher(),
+            context=context,
+            event_log=event_log,
+            deadline=context.deadline,
+            max_workers=2,
+        )
+
+    async def test_a_transient_failure_does_not_cost_the_stream(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        # One blip used to propagate out of the worker and take every
+        # remaining task in its stream with it.
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=WriteLedger())
+        supervisor = self._supervisor(_FlakyProvider(fail_first=2), context, event_log)
+
+        tasks = await supervisor.run(_plan(), tmp_workspace)
+        assert all(t.completed for t in tasks)
+
+    async def test_persistent_failure_stands_down_instead_of_spinning(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        # A provider that is simply down must not burn 200 iterations per
+        # worker; each agent gives up after MAX_CONSECUTIVE_LLM_FAILURES.
+        from noscope.agents import MAX_CONSECUTIVE_LLM_FAILURES
+
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=WriteLedger())
+        provider = _AlwaysFailingProvider()
+        supervisor = self._supervisor(provider, context, event_log)
+
+        tasks = await supervisor.run(_plan(), tmp_workspace)
+
+        # Setup (2 agents) + workers (2 streams), each capped at the retry limit.
+        assert provider.calls <= 4 * MAX_CONSECUTIVE_LLM_FAILURES
+        # The run still returns its tasks rather than raising.
+        assert len(tasks) == 5

--- a/tests/test_supervisor_run.py
+++ b/tests/test_supervisor_run.py
@@ -1,0 +1,250 @@
+"""End-to-end tests for the multi-agent supervisor.
+
+The partitioning helpers are unit-tested elsewhere; this file exercises
+``Supervisor.run`` itself — parallel setup, worker fan-out over the
+partitioned streams, the concurrent audit agent, and the shared write ledger.
+That machinery is the most intricate part of the harness and the part that has
+never actually been *run* in a test. A scripted provider drives it: no key, no
+network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from noscope.conflicts import WriteLedger
+from noscope.llm.base import LLMResponse, Message, ToolCall, ToolSchema, Usage
+from noscope.logging.events import EventLog
+from noscope.planning.models import PlanOutput, PlanTask
+from noscope.supervisor import Supervisor
+from noscope.tools.base import ToolContext
+from noscope.tools.dispatcher import ToolDispatcher
+from noscope.tools.filesystem import WriteFileTool
+
+
+class _WorkerProvider:
+    """Each build agent writes the file for its current task, then marks it done.
+
+    The agent identity is read out of the system prompt, so concurrent agents
+    stay independent without the provider needing any cross-agent state beyond
+    the lock that guards its own counters.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._written: set[str] = set()
+        self._lock = asyncio.Lock()
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        model: str | None = None,
+        json_schema: dict[str, Any] | None = None,
+        effort: str | None = None,
+    ) -> LLMResponse:
+        async with self._lock:
+            self.calls += 1
+        names = {t.name for t in (tools or [])}
+        usage = Usage()
+
+        # The audit agent gets no mark_task_complete tool — it just reports.
+        if "mark_task_complete" not in names:
+            return LLMResponse(content='{"findings": []}', stop_reason="end_turn", usage=usage)
+
+        pending = _pending_task_ids(messages)
+        if not pending:
+            return LLMResponse(content="nothing to do", stop_reason="end_turn", usage=usage)
+
+        task_id = pending[0]
+        async with self._lock:
+            needs_write = task_id not in self._written
+            if needs_write:
+                self._written.add(task_id)
+
+        if needs_write:
+            return LLMResponse(
+                tool_calls=[
+                    ToolCall(
+                        id=f"w-{task_id}",
+                        name="write_file",
+                        arguments={"path": f"{task_id}.py", "content": f"# {task_id}\n"},
+                    )
+                ],
+                usage=usage,
+            )
+        return LLMResponse(
+            tool_calls=[
+                ToolCall(
+                    id=f"d-{task_id}", name="mark_task_complete", arguments={"task_id": task_id}
+                )
+            ],
+            usage=usage,
+        )
+
+
+def _pending_task_ids(messages: list[Message]) -> list[str]:
+    """Task ids this agent was assigned, minus the ones it already marked done."""
+    assigned: list[str] = []
+    for m in messages:
+        if m.role == "user" and "Execute these tasks" in (m.content or ""):
+            for line in (m.content or "").splitlines():
+                if line.startswith("- ["):
+                    assigned.append(line[3 : line.index("]")])
+    done = {
+        str(tc.arguments.get("task_id"))
+        for m in messages
+        for tc in (m.tool_calls or [])
+        if tc.name == "mark_task_complete"
+    }
+    return [t for t in assigned if t not in done]
+
+
+def _dispatcher() -> ToolDispatcher:
+    d = ToolDispatcher()
+    d.register(WriteFileTool())
+    return d
+
+
+def _plan() -> PlanOutput:
+    # t1 is setup (runs alone). t2/t3 form one dependency chain, t4/t5 another,
+    # so partitioning has two independent streams to fan out across workers.
+    return PlanOutput(
+        tasks=[
+            PlanTask(id="t1", title="Setup", kind="edit", description="scaffold"),
+            PlanTask(id="t2", title="A", kind="edit", description="a", depends_on=["t1"]),
+            PlanTask(id="t3", title="B", kind="edit", description="b", depends_on=["t2"]),
+            PlanTask(id="t4", title="C", kind="edit", description="c", depends_on=["t1"]),
+            PlanTask(id="t5", title="D", kind="edit", description="d", depends_on=["t4"]),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+class TestSupervisorRun:
+    async def test_all_tasks_complete_across_parallel_workers(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        ledger = WriteLedger()
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=ledger)
+        provider = _WorkerProvider()
+
+        supervisor = Supervisor(
+            provider=provider,  # type: ignore[arg-type]
+            dispatcher=_dispatcher(),
+            context=context,
+            event_log=event_log,
+            deadline=context.deadline,
+            max_workers=2,
+        )
+        tasks = await supervisor.run(_plan(), tmp_workspace)
+
+        assert [t.id for t in tasks if not t.completed] == [], "every task should finish"
+        # The workers really wrote files, rather than only claiming completion.
+        for task_id in ("t2", "t3", "t4", "t5"):
+            assert (tmp_workspace / f"{task_id}.py").exists()
+
+    async def test_work_is_split_across_two_workers(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        # Two independent chains and two workers should mean genuine fan-out,
+        # not one worker doing everything while the other idles.
+        ledger = WriteLedger()
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=ledger)
+
+        supervisor = Supervisor(
+            provider=_WorkerProvider(),  # type: ignore[arg-type]
+            dispatcher=_dispatcher(),
+            context=context,
+            event_log=event_log,
+            deadline=context.deadline,
+            max_workers=2,
+        )
+        await supervisor.run(_plan(), tmp_workspace)
+
+        writers = {agent for agent in ("worker-0", "worker-1") if ledger.paths_touched_by(agent)}
+        assert writers == {"worker-0", "worker-1"}
+
+    async def test_disjoint_streams_produce_no_write_conflicts(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        # Partitioning exists so workers don't collide. When each task owns its
+        # own file, the ledger should stay clean — a conflict here would mean
+        # the partitioning put dependent work on different workers.
+        ledger = WriteLedger()
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=ledger)
+
+        supervisor = Supervisor(
+            provider=_WorkerProvider(),  # type: ignore[arg-type]
+            dispatcher=_dispatcher(),
+            context=context,
+            event_log=event_log,
+            deadline=context.deadline,
+            max_workers=2,
+        )
+        await supervisor.run(_plan(), tmp_workspace)
+
+        assert ledger.conflicts == [], ledger.summary()
+
+    async def test_single_worker_still_completes_everything(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        # --workers 1 collapses every stream onto one agent; the merge path in
+        # _partition_tasks must still preserve dependency order.
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=WriteLedger())
+
+        supervisor = Supervisor(
+            provider=_WorkerProvider(),  # type: ignore[arg-type]
+            dispatcher=_dispatcher(),
+            context=context,
+            event_log=event_log,
+            deadline=context.deadline,
+            max_workers=1,
+        )
+        tasks = await supervisor.run(_plan(), tmp_workspace)
+        assert all(t.completed for t in tasks)
+
+    async def test_empty_plan_is_a_no_op(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        supervisor = Supervisor(
+            provider=_WorkerProvider(),  # type: ignore[arg-type]
+            dispatcher=_dispatcher(),
+            context=replace(tool_context, workspace=tmp_workspace),
+            event_log=event_log,
+            deadline=tool_context.deadline,
+            max_workers=2,
+        )
+        assert await supervisor.run(PlanOutput(tasks=[]), tmp_workspace) == []
+
+    async def test_build_does_not_wait_for_the_auditor(
+        self, tool_context: ToolContext, event_log: EventLog, tmp_workspace: Path
+    ) -> None:
+        # The auditor loops until BUILD is nearly over. Gathering it alongside
+        # the workers meant a build finishing in seconds still sat idle for the
+        # rest of BUILD's budget — burning the timebox this tool exists to
+        # protect. With a 300s deadline this test would take minutes if the
+        # supervisor waited on the audit task.
+        import time
+
+        context = replace(tool_context, workspace=tmp_workspace, write_ledger=WriteLedger())
+        supervisor = Supervisor(
+            provider=_WorkerProvider(),  # type: ignore[arg-type]
+            dispatcher=_dispatcher(),
+            context=context,
+            event_log=event_log,
+            deadline=context.deadline,
+            max_workers=2,
+        )
+
+        started = time.monotonic()
+        await supervisor.run(_plan(), tmp_workspace)
+        elapsed = time.monotonic() - started
+
+        assert context.deadline.total_seconds >= 60, "fixture must have a long deadline to matter"
+        assert elapsed < 10, f"supervisor blocked on the audit agent for {elapsed:.1f}s"

--- a/tests/test_tools/test_docker.py
+++ b/tests/test_tools/test_docker.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from noscope.tools.docker import build_write_command, safe_container_path
+from noscope.tools.docker import build_write_command, preflight_docker, safe_container_path
 
 
 class TestSafeContainerPath:
@@ -59,3 +59,49 @@ class TestBuildWriteCommand:
     def test_rejects_unsafe_path(self) -> None:
         with pytest.raises(ValueError):
             build_write_command("../escape.py", "data")
+
+
+@pytest.mark.asyncio
+class TestPreflightDocker:
+    async def test_missing_binary_is_explained(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("noscope.tools.docker.shutil.which", lambda _: None)
+        problem = await preflight_docker()
+        assert problem is not None
+        assert "docker" in problem
+        # The point of the check is telling the user what to do instead.
+        assert "--sandbox" in problem
+
+    async def test_unreachable_daemon_reports_what_it_said(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("noscope.tools.docker.shutil.which", lambda _: "/usr/bin/docker")
+
+        async def fake_exec(*args: object, **kwargs: object) -> object:
+            class _Proc:
+                returncode = 1
+
+                async def communicate(self) -> tuple[bytes, bytes]:
+                    return b"", b"Cannot connect to the Docker daemon\nmore detail"
+
+            return _Proc()
+
+        monkeypatch.setattr("noscope.tools.docker.asyncio.create_subprocess_exec", fake_exec)
+        problem = await preflight_docker()
+        assert problem is not None
+        assert "daemon is not reachable" in problem
+        assert "Cannot connect to the Docker daemon" in problem
+
+    async def test_healthy_daemon_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("noscope.tools.docker.shutil.which", lambda _: "/usr/bin/docker")
+
+        async def fake_exec(*args: object, **kwargs: object) -> object:
+            class _Proc:
+                returncode = 0
+
+                async def communicate(self) -> tuple[bytes, bytes]:
+                    return b"27.0.3\n", b""
+
+            return _Proc()
+
+        monkeypatch.setattr("noscope.tools.docker.asyncio.create_subprocess_exec", fake_exec)
+        assert await preflight_docker() is None

--- a/tests/test_tools/test_shell.py
+++ b/tests/test_tools/test_shell.py
@@ -28,6 +28,25 @@ class TestShellTool:
         assert result.status == "error"
         assert "timed out" in result.display.lower()
 
+    async def test_timeout_kills_whole_process_tree(self, tool_context: ToolContext) -> None:
+        # A timed-out command must not leave orphans behind. Killing only the
+        # shell leaves grandchildren running, still holding the output pipes —
+        # which also made the timeout path block for the command's full runtime.
+        import time
+
+        started = time.monotonic()
+        result = await ShellTool().execute(
+            # The subshell forces a grandchild: `sh -c` cannot exec-optimize it.
+            {"command": "(sleep 30) & wait", "timeout": 1},
+            tool_context,
+        )
+        elapsed = time.monotonic() - started
+
+        assert result.status == "error"
+        assert "timed out" in result.display.lower()
+        # Generous, but far below the 30s the orphan would have kept us waiting.
+        assert elapsed < 10, f"timeout path blocked on an orphan for {elapsed:.1f}s"
+
     async def test_denied_command(self, tool_context: ToolContext) -> None:
         tool = ShellTool()
         result = await tool.execute({"command": "sudo rm -rf /"}, tool_context)

--- a/uv.lock
+++ b/uv.lock
@@ -538,6 +538,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -556,6 +557,7 @@ requires-dist = [
     { name = "rich" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "types-pyyaml", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
 
@@ -909,6 +911,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Everything here was built and verified without spending a token — the point being that when you next run this against a real model, anything that fails should be about the model, not the plumbing.

**Four real bugs found, three of them by writing tests for code that had never actually been run:**

1. **A stalled request could outrun the timebox entirely.** The hard deadline is the product, but it's *cooperative* — checked between agent iterations — so it can't interrupt a request in flight. Both SDKs default to a 600-second read timeout with retries on top. On a 5-minute run that isn't a degraded guarantee, it's no guarantee. Every provider call now passes through a `DeadlineBoundProvider` capped at `NOSCOPE_REQUEST_TIMEOUT` (120s) or the remaining timebox. The `wait_for` sits outside the SDK call, so the bound covers the SDK's internal retries too; it's applied once in the orchestrator, so every call site is covered without touching any of them.

2. **BUILD idled until the audit agent's loop expired.** The auditor is designed to poll until the phase is nearly over, and it was `gather`ed alongside the workers — so a build whose workers finished in seconds still blocked for the rest of BUILD's budget. On a 30-minute run that's up to ~16 wasted minutes, in the one tool where wasted minutes are the whole point. Found because the first `Supervisor.run` test hung.

3. **Timed-out commands leaked their process trees.** `sh -c "npm run dev"` was killed at the shell only, leaving the server running as an orphan still holding the stdout pipe — port stayed bound, and `proc.wait()` blocked until the orphan happened to exit. The test suite was spending 20 of its 24 seconds on exactly that. Children now start in their own session and a timeout `killpg`s the tree. Same fix for the `docker exec` client and Ctrl+C on `--serve`. Suite: 24s → 6s, and the `PytestUnraisableExceptionWarning` noise turned out to be this bug all along.

4. **One transient LLM failure cost a worker its entire stream.** Tasks are partitioned per-worker, so an exception escaping one agent silently took every remaining task with it — `return_exceptions=True` kept the run alive, which is what made it silent. Agents now tolerate three consecutive failures, then stand down.

**New capability:**

- **Write-conflict detection.** The planner is told to give each task its own files; nothing enforced it. Two workers could both "succeed", last write wins, and the run reports a clean build over discarded work. A shared `WriteLedger` now records the last writer of each path; a different agent overwriting it with different content warns that agent *in its own conversation* (the only channel back into it), logs a `write.conflict` event, and adds a section to the handoff — appended after generation, so the model writing the report can't omit it. Warned, not blocked: overlap is sometimes legitimate.

**Making failures legible instead of mysterious:**

- `--dry-run`, `doctor --live`, and actionable API errors (bad key / wrong model / rate limit / overload each get a diagnosis and the fix).
- `--sandbox` preflights Docker before PLAN instead of dying mid-build, and distinguishes not-installed from daemon-down. `doctor` now reports the daemon rather than just the binary on `PATH`.
- `doctor` exits non-zero when a requirement is missing, so it works as a gate. Fixing that exposed why it couldn't before: `all_ok` treated any check whose name lacked the word "optional" as required, so "OpenAI key not set" failed the whole thing even with a valid Anthropic key.

**Coverage for the parts that had none:**

- Provider wire shapes, with both SDKs mocked — the layer most likely to break silently on an SDK change, and the one that costs real tokens to discover live.
- `Supervisor.run` itself: parallel setup, worker fan-out over partitioned streams, the concurrent auditor, the shared ledger. The partitioning helpers had unit tests; the supervisor had never been run.
- Conversation context management, with trimming that never orphans a tool result.
- Every shipped example spec parses.

## Why

The audit found the provider layer had no assertions anywhere and nothing tested whether the tool actually *runs*. Both gaps cost tokens to discover live. Three of the four bugs above were only findable by exercising code paths that had tests for their helpers but never for themselves.

## How

The dry-run provider dispatches on call *shape* rather than being wired in per phase: a structured-output request is the planner, a tool set containing `confirm_running` is VERIFY, one containing `mark_task_complete` is a build agent, a plain call is HANDOFF. That keeps it honest — it exercises the same dispatch path a real provider takes, which is why it works as a CI smoke test.

CI gained a `smoke` job that drives the real CLI through all six phases and asserts on the artifact, the handoff, and `run.complete` in the event log, plus `ruff format --check` and a least-privilege `permissions:` block (CodeQL finding).

## Testing

- [x] `make test` passes — 279 tests, ~6s (was 227 in 24s)
- [x] `make lint` passes — plus `ruff format --check`, newly added to CI
- [x] `make typecheck` passes — `mypy --strict`, 41 files
- [x] New tests added for new functionality

CI green on every commit in this branch. Beyond the assertions:

- All four example specs dry-run cleanly end to end.
- `run --sandbox --dry-run` on a box with the docker CLI but no daemon aborts before PLAN with the actionable message and **zero** model calls.
- `doctor` exits 1 with no key, 0 with one key, and reports the daemon honestly.
- **Mutation-checked the three bug-fix tests** — reverting each fix makes its test fail (the timing ones by hanging past 60s). They bite.

## Related Issues

None.